### PR TITLE
fix(ci): enforce validation policy and restore main release progression

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,16 @@ jobs:
             VERSION="${{ steps.next_version.outputs.version }}-pr.${{ github.event.pull_request.number }}-commit.${SHORT_SHA}"
           else
             VERSION="${{ steps.next_version.outputs.version }}"
+
+            # Ensure every push to main yields a unique release version even when
+            # commit types do not trigger a semantic bump (for example build/chore).
+            LATEST_TAG=$(git tag --list "v*" --sort=-version:refname | head -n 1 || true)
+            if [[ -n "${LATEST_TAG}" && "${VERSION}" == "${LATEST_TAG}" ]]; then
+              BASE="${LATEST_TAG#v}"
+              IFS='.' read -r MAJOR MINOR PATCH <<< "${BASE}"
+              PATCH=$((PATCH + 1))
+              VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+            fi
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/lint-pull-request.yaml
+++ b/.github/workflows/lint-pull-request.yaml
@@ -18,13 +18,37 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Bypass title validation for Dependabot
+      - name: Normalize Dependabot PR title to Conventional Commits
         if: github.event.pull_request.user.login == 'dependabot[bot]'
-        run: echo "Dependabot pull request titles are generated automatically and are exempt from semantic title linting."
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const currentTitle = context.payload.pull_request.title.trim();
+            const conventionalCommitPattern =
+              /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?:\s.+/i;
+
+            if (conventionalCommitPattern.test(currentTitle)) {
+              core.info("Dependabot title already matches Conventional Commits format.");
+              return;
+            }
+
+            const normalizedTitleBody =
+              currentTitle.charAt(0).toLowerCase() + currentTitle.slice(1);
+            const updatedTitle = `chore(deps): ${normalizedTitleBody}`;
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              title: updatedTitle,
+            });
+
+            core.info(`Updated Dependabot PR title to: ${updatedTitle}`);
 
       - name: Validate PR title
         id: lint_pr_title
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: amannn/action-semantic-pull-request@v6
         with:
           validateSingleCommit: true
@@ -37,11 +61,11 @@ jobs:
           header: pr-title-lint-error
           message: |
             Hey there and thank you for opening this pull request! 👋🏼
-            
+
             We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
 
             Details:
-            
+
             ```
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
@@ -49,7 +73,7 @@ jobs:
       # Delete a previous comment when the issue has been resolved
       - if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && steps.lint_pr_title.outputs.error_message == null }}
         uses: marocchino/sticky-pull-request-comment@v2
-        with:   
+        with:
           header: pr-title-lint-error
           delete: true
 
@@ -65,4 +89,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash
-    

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,17 @@ This file is the fast-start guidance for any AI agent or contributor working in 
 - The only deployed environment is driven from `main`.
 - Deployment consumes `latest` tags from successful `main` builds, while releases should still preserve traceability metadata.
 
+## Agent Decision Governance
+- Do not make major architectural, security, deployment, branch-protection, or validation-policy decisions unilaterally.
+- For decisions with non-obvious tradeoffs, present options, risks, and a recommendation, then wait for user direction before proceeding.
+- If a decision changes enforcement level (for example, required checks or policy gates), explicit user approval is required.
+
+## Validation And Automation Rules
+- Do not bypass, disable, or weaken validation gates to make a failing workflow pass.
+- Do not exempt specific actors (including `dependabot[bot]`) from required validation checks unless the user explicitly approves that policy change.
+- Fix root causes in code or automation so all contributors and bots can satisfy the same standards.
+- Treat reductions in auditability, traceability, or policy enforcement as regressions.
+
 ## Working Norms
 - Favor declarative configuration over manual cluster mutation.
 - Keep services independently buildable and testable.

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -78,3 +78,14 @@ These standards apply to both human contributors and AI agents working in Asteri
 - If a choice affects integration, prefer explicit API contracts over implicit coupling.
 - If a choice affects runtime secrets, use External Secrets Operator with AWS Secrets Manager.
 - If a choice affects internal trust, assume service mesh mTLS and mesh policy are the baseline.
+
+## 12. Validation Integrity
+- Required validation gates must remain enforced for all contributors, including automation and bots.
+- Do not bypass, disable, or weaken checks as a workaround for failing automation.
+- When automation (for example Dependabot) cannot satisfy a validation, fix the underlying workflow or automation behavior so policy remains intact.
+- Any intentional reduction in validation enforcement requires explicit approval from the repository owner and should be documented in-repo with rationale.
+
+## 13. Decision Governance
+- Major decisions (architecture, security posture, deployment model, branch protection, required checks, and policy gate changes) require explicit user or maintainer direction.
+- Contributors and AI agents should present tradeoffs and recommendations, then pause for approval before implementing major policy shifts.
+- If there is uncertainty about whether a change is a major decision, treat it as major and escalate.


### PR DESCRIPTION
## Summary
- replace the Dependabot PR-title validation bypass with automatic title normalization to Conventional Commits
- keep semantic PR title validation enabled for all actors
- codify agent decision-governance and validation-integrity standards in repository docs
- ensure every push to `main` produces a new release version by applying a patch fallback when semantic version resolution does not advance

## Why
- prevents weakening policy controls by actor exemption
- aligns agent behavior with explicit user approval for major decisions
- restores predictable release creation from `main` when commit types like `build`/`chore` are merged

## Validation
- verified clean diff scope against `origin/main` (4 files)
- reviewed updated workflow logic for title normalization and version fallback
