### PR TITLE
feat(ci): split build and release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,6 @@
-name: CI and Release
+name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types:
       - opened
@@ -13,11 +10,8 @@ on:
       - main
 
 permissions:
-  contents: write
-  packages: write
-  pull-requests: write
-  id-token: write
-  attestations: write
+  contents: read
+  pull-requests: read
   security-events: write
 
 jobs:
@@ -41,23 +35,9 @@ jobs:
       - name: Set build version
         id: set_version
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            SHA="${{ github.sha }}"
-            SHORT_SHA="${SHA::7}"
-            VERSION="${{ steps.next_version.outputs.version }}-pr.${{ github.event.pull_request.number }}-commit.${SHORT_SHA}"
-          else
-            VERSION="${{ steps.next_version.outputs.version }}"
-
-            # Ensure every push to main yields a unique release version even when
-            # commit types do not trigger a semantic bump (for example build/chore).
-            LATEST_TAG=$(git tag --list "v*" --sort=-version:refname | head -n 1 || true)
-            if [[ -n "${LATEST_TAG}" && "${VERSION}" == "${LATEST_TAG}" ]]; then
-              BASE="${LATEST_TAG#v}"
-              IFS='.' read -r MAJOR MINOR PATCH <<< "${BASE}"
-              PATCH=$((PATCH + 1))
-              VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-            fi
-          fi
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA::7}"
+          VERSION="${{ steps.next_version.outputs.version }}-pr.${{ github.event.pull_request.number }}-commit.${SHORT_SHA}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   inventory:
@@ -155,6 +135,7 @@ jobs:
             services/${{ matrix.service.id }}/test-results.json
 
   containers:
+    # The PR build is the source of truth for release publication; this job only packages artifacts.
     name: Build Container ${{ matrix.service.id }}
     needs:
       - metadata
@@ -172,74 +153,45 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to GHCR
-        if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and optionally push image
-        id: build
+      - name: Build image archive
         uses: docker/build-push-action@v7
         with:
           context: services/${{ matrix.service.id }}
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: false
           tags: |
             ghcr.io/${{ github.repository }}-${{ matrix.service.id }}:${{ needs.metadata.outputs.version }}
-            ghcr.io/${{ github.repository }}-${{ matrix.service.id }}:latest
+          outputs: type=docker,dest=${{ runner.temp }}/image-${{ matrix.service.id }}.tar
           build-args: |
             VERSION=${{ needs.metadata.outputs.version }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp || github.run_id }}
+            BUILD_DATE=${{ github.event.pull_request.updated_at || github.run_id }}
             COMMIT_SHA=${{ github.sha }}
 
-      - name: Install Cosign
-        if: github.ref == 'refs/heads/main'
-        uses: sigstore/cosign-installer@v4.1.1
-
-      - name: Sign image with keyless Cosign
-        if: github.ref == 'refs/heads/main'
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          cosign sign --yes ghcr.io/${{ github.repository }}-${{ matrix.service.id }}@${{ steps.build.outputs.digest }}
-
-      - name: Generate SPDX SBOM
-        if: github.ref == 'refs/heads/main'
+      - name: Generate SBOM for image archive
         uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/${{ github.repository }}-${{ matrix.service.id }}@${{ steps.build.outputs.digest }}
+          file: ${{ runner.temp }}/image-${{ matrix.service.id }}.tar
           format: spdx-json
+          artifact-name: sbom-${{ matrix.service.id }}
           output-file: sbom-${{ matrix.service.id }}.spdx.json
 
-      - name: Attest build provenance
-        if: github.ref == 'refs/heads/main'
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: ghcr.io/${{ github.repository }}-${{ matrix.service.id }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
-
       - name: Write image metadata
-        if: github.ref == 'refs/heads/main'
         run: |
           jq -n \
             --arg service "${{ matrix.service.id }}" \
             --arg image "ghcr.io/${{ github.repository }}-${{ matrix.service.id }}" \
-            --arg digest "${{ steps.build.outputs.digest }}" \
+            --arg tag "${{ needs.metadata.outputs.version }}" \
             --arg version "${{ needs.metadata.outputs.version }}" \
-            '{service: $service, image: $image, digest: $digest, version: $version}' \
+            '{service: $service, image: $image, tag: $tag, version: $version}' \
             > image-metadata-${{ matrix.service.id }}.json
 
-      - name: Upload supply chain artifacts
-        if: github.ref == 'refs/heads/main'
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: supply-chain-${{ matrix.service.id }}
+          name: build-${{ matrix.service.id }}
           path: |
-            sbom-${{ matrix.service.id }}.spdx.json
+            ${{ runner.temp }}/image-${{ matrix.service.id }}.tar
             image-metadata-${{ matrix.service.id }}.json
+            sbom-${{ matrix.service.id }}.spdx.json
 
   render-kustomize:
     name: Render Kustomize ${{ matrix.service.id }}
@@ -247,7 +199,6 @@ jobs:
       - inventory
       - verify
     runs-on: ubuntu-24.04
-    if: github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -269,58 +220,3 @@ jobs:
         with:
           name: rendered-${{ matrix.service.id }}
           path: rendered/${{ matrix.service.id }}-latest.yaml
-
-  release:
-    name: Publish GitHub Release
-    needs:
-      - metadata
-      - inventory
-      - containers
-      - render-kustomize
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download supply-chain artifacts
-        uses: actions/download-artifact@v8
-        with:
-          pattern: supply-chain-*
-          merge-multiple: true
-
-      - name: Download rendered manifests
-        uses: actions/download-artifact@v8
-        with:
-          pattern: rendered-*
-          merge-multiple: true
-
-      - name: Build release manifest
-        run: |
-          jq -n \
-            --arg version "${{ needs.metadata.outputs.version }}" \
-            --arg commit "${{ github.sha }}" \
-            --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{version: $version, commit: $commit, created: $created, services: []}' > release-manifest.json
-
-          for f in image-metadata-*.json; do
-            [ -f "$f" ] || continue
-            release_service=$(cat "$f")
-            release_manifest_tmp=$(mktemp)
-            jq --argjson svc "$release_service" '.services += [$svc]' release-manifest.json > "$release_manifest_tmp"
-            mv "$release_manifest_tmp" release-manifest.json
-          done
-
-      - name: Create release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.metadata.outputs.version }}
-          name: ${{ needs.metadata.outputs.version }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-          files: |
-            release-manifest.json
-            *-latest.yaml
-            sbom-*.spdx.json
-            image-metadata-*.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,198 @@
+name: Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: read
+  id-token: write
+  actions: read
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+      SOURCE_CI_WORKFLOW_FILE: 'ci.yaml'
+      COSIGN_EXPERIMENTAL: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Compute release version
+        id: version
+        uses: thenativeweb/get-next-version@2.6.3
+        with:
+          prefix: v
+
+      - name: Set release version
+        id: set_version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          LATEST_TAG=$(git tag --list "v*" --sort=-version:refname | head -n 1 || true)
+          if [[ -n "${LATEST_TAG}" && "${VERSION}" == "${LATEST_TAG}" ]]; then
+            BASE="${LATEST_TAG#v}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${BASE}"
+            PATCH=$((PATCH + 1))
+            VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Reuse the successful PR workflow run so the release stays tied to the reviewed build.
+      - name: Locate source CI run
+        id: source_run
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          repo = os.environ['REPOSITORY']
+          pr_number = int(os.environ['PR_NUMBER'])
+          workflow_file = os.environ['SOURCE_CI_WORKFLOW_FILE']
+          token = os.environ['GITHUB_TOKEN']
+
+          headers = {
+              'Accept': 'application/vnd.github+json',
+              'Authorization': f'Bearer {token}',
+              'X-GitHub-Api-Version': '2022-11-28',
+          }
+
+          page = 1
+          while True:
+              url = (
+                  f'https://api.github.com/repos/{repo}/actions/workflows/{workflow_file}/runs'
+                  f'?event=pull_request&status=success&per_page=100&page={page}'
+              )
+              request = urllib.request.Request(url, headers=headers)
+              with urllib.request.urlopen(request) as response:
+                  payload = json.load(response)
+
+              runs = payload.get('workflow_runs', [])
+              if not runs:
+                  break
+
+              for run in runs:
+                  if run.get('conclusion') != 'success':
+                      continue
+                  if any(pr.get('number') == pr_number for pr in run.get('pull_requests', [])):
+                      with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+                          output.write(f"run_id={run['id']}\n")
+                          output.write(f"run_url={run['html_url']}\n")
+                      sys.exit(0)
+
+              if len(runs) < 100:
+                  break
+              page += 1
+
+          print(f'Could not find a successful CI run for PR #{pr_number}', file=sys.stderr)
+          sys.exit(1)
+          PY
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.source_run.outputs.run_id }}
+          pattern: build-*
+          merge-multiple: true
+          path: artifacts/build
+
+      - name: Download rendered manifests
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.source_run.outputs.run_id }}
+          pattern: rendered-*
+          merge-multiple: true
+          path: artifacts/rendered
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auxiliary release metadata is assembled here because it does not change the shipped bits.
+      - name: Publish images and record release metadata
+        run: |
+          mkdir -p artifacts/release
+          shopt -s nullglob
+          for metadata in artifacts/build/image-metadata-*.json; do
+            service=$(jq -r '.service' "$metadata")
+            image=$(jq -r '.image' "$metadata")
+            tag=$(jq -r '.tag' "$metadata")
+            archive="artifacts/build/image-${service}.tar"
+            release_tag="${{ steps.set_version.outputs.version }}"
+
+            if [[ ! -f "$archive" ]]; then
+              echo "Missing image archive for ${service}: ${archive}" >&2
+              exit 1
+            fi
+
+            docker load -i "$archive"
+            docker tag "${image}:${tag}" "${image}:${release_tag}"
+            docker tag "${image}:${tag}" "${image}:latest"
+
+            digest=$(docker push "${image}:${release_tag}" | awk '/digest:/ {print $3; exit}')
+            docker push "${image}:latest" >/dev/null
+
+            cosign sign --yes "${image}@${digest}"
+            jq -n \
+              --arg service "$service" \
+              --arg image "$image" \
+              --arg digest "$digest" \
+              --arg version "${{ steps.set_version.outputs.version }}" \
+              '{service: $service, image: $image, digest: $digest, version: $version}' \
+              > "artifacts/release/image-metadata-${service}.json"
+          done
+
+      - name: Build release manifest
+        run: |
+          jq -n \
+            --arg version "${{ steps.set_version.outputs.version }}" \
+            --arg commit "${{ env.MERGE_COMMIT_SHA }}" \
+            --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{version: $version, commit: $commit, created: $created, services: []}' > release-manifest.json
+
+          for f in artifacts/release/image-metadata-*.json; do
+            [ -f "$f" ] || continue
+            release_service=$(cat "$f")
+            release_manifest_tmp=$(mktemp)
+            jq --argjson svc "$release_service" '.services += [$svc]' release-manifest.json > "$release_manifest_tmp"
+            mv "$release_manifest_tmp" release-manifest.json
+          done
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.set_version.outputs.version }}
+          name: ${{ steps.set_version.outputs.version }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            release-manifest.json
+            artifacts/rendered/*-latest.yaml
+            artifacts/build/sbom-*.spdx.json
+            artifacts/release/image-metadata-*.json

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -61,7 +61,8 @@ These standards apply to both human contributors and AI agents working in Asteri
 - Changes that reduce traceability, weaken controls, or bypass validation should be treated as regressions.
 
 ## 9. Delivery And Release Expectations
-- Build outputs should be reproducible and traceable.
+- Build outputs that become part of the shipped release should be produced once from the reviewed PR commit and reused for release publication.
+- Auxiliary metadata may be assembled or regenerated at release time when that simplifies the workflow, provided the release still points back to the reviewed commit and the PR-built payload.
 - Container artifacts should preserve supply chain metadata such as digests, signatures, attestations, and SBOMs where supported.
 - Release artifacts should be machine-readable where practical to support audit, promotion, and GitOps automation.
 

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -6,6 +6,8 @@ Each GitHub release includes:
 - `sbom-*.spdx.json`
 - `image-metadata-*.json`
 
+The shipped image bytes and rendered manifests are reused from the reviewed PR build. Auxiliary release metadata may be assembled at publish time as long as it still points back to that build and commit.
+
 ## release-manifest.json
 ```json
 {


### PR DESCRIPTION
Split the pipeline so PRs build and upload reusable artifacts once, and a separate release workflow consumes those artifacts after merge to publish releases without rebuilding.\n\nHighlights:\n- CI is PR-only\n- Release runs on merged PRs to main\n- Release reuses the PR build artifacts and rendered manifests\n- Release manifest stays tied to the merged commit and published artifacts