### PR TITLE
docs: note main-branch PR branch refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ GitHub Actions in `.github/workflows/ci.yaml` provides:
 - image build and GHCR publish,
 - image signing, SLSA attestation, SBOM generation,
 - rendered Kustomize release assets and machine-readable release manifest.
+
+Main-branch pushes also refresh open PR branches through `.github/workflows/update-pr-branches.yaml`.


### PR DESCRIPTION
## What
- Add a brief README note that `main` pushes refresh open PR branches.

## Why
- This is a small, low-risk change to support testing the PR close path and release automation behavior.

## Validation
- `git diff --check`
- No code or contract changes.
