### PR TITLE
ci: stop enabling auto-merge in lint workflow

### DIFF
--- a/.github/workflows/lint-pull-request.yaml
+++ b/.github/workflows/lint-pull-request.yaml
@@ -76,16 +76,3 @@ jobs:
         with:
           header: pr-title-lint-error
           delete: true
-
-  enable-automerge:
-    name: Enable auto-merge
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Enable auto-merge
-        if: success()
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: squash

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ GitHub Actions in `.github/workflows/ci.yaml` provides:
 - image build and GHCR publish,
 - image signing, SLSA attestation, SBOM generation,
 - rendered Kustomize release assets and machine-readable release manifest.
+
+Main-branch pushes also refresh open PR branches through `.github/workflows/update-pr-branches.yaml`.


### PR DESCRIPTION
## What
- Remove the auto-merge enablement step from the PR lint workflow.
- Keep the title validation and PR-comment cleanup behavior intact.

## Why
- We want manual control over merging while we test whether auto-merge was influencing downstream `pull_request.closed` and `push` automation.

## Validation
- `git diff --check`
- Reviewed the workflow diff to confirm only the auto-merge job was removed.
