### PR TITLE
chore: clarify release automation guidance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
   release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
+    environment: release
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPOSITORY: ${{ github.repository }}
@@ -69,7 +70,7 @@ jobs:
       - name: Validate release automation configuration
         env:
           CD_REPO_FULL_NAME: ${{ vars.CD_REPO_FULL_NAME }}
-          CD_REPO_GITHUB_APP_ID: ${{ secrets.CD_REPO_GITHUB_APP_ID }}
+          CD_REPO_GITHUB_APP_ID: ${{ vars.CD_REPO_GITHUB_APP_ID }}
           CD_REPO_GITHUB_APP_PRIVATE_KEY: ${{ secrets.CD_REPO_GITHUB_APP_PRIVATE_KEY }}
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
           ARGOCD_SERVER: ${{ vars.ARGOCD_SERVER }}
@@ -222,7 +223,7 @@ jobs:
             artifacts/release-source/sbom-*.spdx.json
             artifacts/release/image-metadata-*.json
 
-      - name: Resolve CD repository
+      - name: Resolve GitOps repository
         id: cd_repo
         env:
           CD_REPO_FULL_NAME: ${{ vars.CD_REPO_FULL_NAME }}
@@ -242,16 +243,16 @@ jobs:
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "full_name=${CD_REPO_FULL_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Create CD repository app token
+      - name: Create os-config GitHub App token
         id: cd_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.CD_REPO_GITHUB_APP_ID }}
+          app-id: ${{ vars.CD_REPO_GITHUB_APP_ID }}
           private-key: ${{ secrets.CD_REPO_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ steps.cd_repo.outputs.owner }}
           repositories: ${{ steps.cd_repo.outputs.name }}
 
-      - name: Checkout CD repository
+      - name: Checkout os-config repository
         uses: actions/checkout@v6
         with:
           repository: ${{ steps.cd_repo.outputs.full_name }}
@@ -263,7 +264,7 @@ jobs:
       - name: Install Kustomize
         uses: imranismail/setup-kustomize@v3
 
-      - name: Promote release in CD repository
+      - name: Promote release in GitOps repository
         run: |
           scripts/release/promote-os-config.py \
             --repo-dir os-config \
@@ -309,7 +310,7 @@ jobs:
           ARGOCD_APP_NAMESPACE: ${{ vars.ARGOCD_APP_NAMESPACE }}
         run: |
           if [[ -z "$ARGOCD_AUTH_TOKEN" ]]; then
-            echo "Repository secret ARGOCD_AUTH_TOKEN must be configured." >&2
+            echo "Release environment secret ARGOCD_AUTH_TOKEN must be configured." >&2
             exit 1
           fi
           if [[ -z "$ARGOCD_SERVER" || -z "$ARGOCD_APP_NAME" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ This file is the fast-start guidance for any AI agent or contributor working in 
 - Pull request titles must use Conventional Commits format, because PR title linting is enforced in GitHub Actions.
 - Pull request branches should use signed commits so GitHub can verify the change origin.
 - CD is handled through OpenShift GitOps with Kustomize from a separate Argo CD repository.
+- Release automation runs in the GitHub Actions `release` environment; keep release-only credentials there.
+- Use a GitHub App installation token for the cross-repo promotion commit into `os-config` instead of a long-lived PAT.
+- Argo CD automation should use the `asterism-release` token-only local user configured in the GitOps repo, not the human SSO path.
 - The only deployed environment is driven from `main`.
 - Deployment consumes `latest` tags from successful `main` builds, while releases should still preserve traceability metadata.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This file is the fast-start guidance for any AI agent or contributor working in 
 - Pull requests must build, lint, and test to an enterprise-minded security and compliance standard.
 - Pull request titles must use Conventional Commits format, because PR title linting is enforced in GitHub Actions.
 - Pull request branches should use signed commits so GitHub can verify the change origin.
+- Asterism repository changes should move through pull requests and merge review; the only direct push in the release flow belongs to the separate GitOps repository.
 - CD is handled through OpenShift GitOps with Kustomize from a separate Argo CD repository.
 - Release automation runs in the GitHub Actions `release` environment; keep release-only credentials there.
 - Use a GitHub App installation token for the cross-repo promotion commit into `os-config` instead of a long-lived PAT.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,7 @@ GitHub Actions pipeline includes:
 - security scanning and auditable outputs,
 - PR-built container archives, release-time GHCR push for immutable `vX.Y.Z` and moving `latest` tags,
 - keyless image signing and SBOM generation,
+- release automation in the GitHub Actions `release` environment with environment-scoped release credentials,
 - GitHub Release assets including rendered Kustomize manifests and machine-readable release metadata.
 
 ## GitOps Flow

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -39,6 +39,7 @@ These standards apply to both human contributors and AI agents working in Asteri
 - Secrets must not be committed to the repository.
 - CI should avoid printing or persisting sensitive values in logs or artifacts.
 - Environment-specific confidential values belong in secret management and deployment configuration, not in application source.
+- GitHub Actions release-only credentials should live in the `release` environment so they are only exposed to the release job.
 
 ## 6. OpenShift And Deployment Model
 - Deployment is GitOps-driven through OpenShift GitOps using Kustomize.

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -10,6 +10,8 @@ The shipped image bytes and rendered manifests are reused from the reviewed PR b
 
 After image publication succeeds, release automation commits the matching Asterism release ref to the separate GitOps repository and adds pod-template annotations that force a rollout while deployments continue to reference `:latest`. Argo CD verification must confirm the app is synced and healthy and that running pod image IDs match the release manifest digests.
 
+The release workflow runs in the GitHub Actions `release` environment. Store release-only credentials there so they are only exposed to the release job.
+
 ## release-manifest.json
 ```json
 {
@@ -35,14 +37,19 @@ After image publication succeeds, release automation commits the matching Asteri
 Consumers (GitOps automation, audit jobs, or promotion tooling) can parse this file without scraping release notes.
 
 ## Required Release Configuration
-- GitHub App credentials for the private GitOps repository:
-  - `CD_REPO_GITHUB_APP_ID`
-  - `CD_REPO_GITHUB_APP_PRIVATE_KEY`
+- GitHub App credentials used by the release workflow to update the private GitOps repository (`os-config`):
+  - Environment secret: `CD_REPO_GITHUB_APP_PRIVATE_KEY`
+  - Repository variable: `CD_REPO_GITHUB_APP_ID`
 - Argo CD verification credential:
-  - `ARGOCD_AUTH_TOKEN`
+  - Environment secret: `ARGOCD_AUTH_TOKEN`
 - Repository variables:
   - `CD_REPO_FULL_NAME`, for example `jlfowle/os-config`
   - `ARGOCD_SERVER`
   - `ARGOCD_APP_NAME`
+- Optional repository variables:
   - `ARGOCD_PROJECT`
   - `ARGOCD_APP_NAMESPACE` when the namespace cannot be inferred from the Argo CD application
+
+This GitHub App is for the release workflow's promotion commit into `os-config`; it is separate from any Argo CD repository connectivity or human SSO setup.
+
+For Argo CD instances that use OpenShift OAuth for human access, keep the SSO configuration separate from automation access. Define a local Argo CD user with `apiKey: true` and `login: false` in the Argo CD custom resource, then read the generated `{username}-local-user` secret and store its `apiToken` value in `ARGOCD_AUTH_TOKEN` for the `release` environment.


### PR DESCRIPTION
Clarify the Asterism release workflow boundary: run release automation in the GitHub Actions release environment, use the GitHub App token for the cross-repo promotion into os-config, and keep Asterism repository changes PR-driven. Also document the release-only credential placement and release-bot boundary in AGENTS.md.