### PR TITLE
fix(release): make reruns idempotent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,8 +53,20 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      # If this merge commit already has a published release, reuse that manifest and version instead of minting another one.
+      - name: Resolve release state
+        id: release_state
+        run: |
+          scripts/release/resolve-release-state.sh \
+            --repo "$REPOSITORY" \
+            --commit "$MERGE_COMMIT_SHA" \
+            --fallback-version "${{ steps.set_version.outputs.version }}" \
+            --manifest-path release-manifest.json \
+            --token "$GITHUB_TOKEN"
+
       - name: Discover release services
         id: inventory
+        if: steps.release_state.outputs.release_exists != 'true'
         working-directory: services
         run: |
           SERVICES=$(./inventory.sh)
@@ -88,9 +100,9 @@ jobs:
             exit 1
           fi
 
-      # Reuse the successful PR workflow run from the exact head SHA so the release stays tied to the reviewed build.
       - name: Locate source CI run
         id: source_run
+        if: steps.release_state.outputs.release_exists != 'true'
         run: |
           python3 <<'PY'
           import json
@@ -140,7 +152,9 @@ jobs:
           sys.exit(1)
           PY
 
+      # Reuse the successful PR workflow run from the exact head SHA so the release stays tied to the reviewed build.
       - name: Download build artifacts
+        if: steps.release_state.outputs.release_exists != 'true'
         uses: actions/download-artifact@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -151,6 +165,7 @@ jobs:
           path: artifacts/build
 
       - name: Normalize release source artifacts
+        if: steps.release_state.outputs.release_exists != 'true'
         env:
           EXPECTED_SERVICES_JSON: ${{ steps.inventory.outputs.containerized }}
         run: |
@@ -160,6 +175,7 @@ jobs:
             --expected-services-json "$EXPECTED_SERVICES_JSON"
 
       - name: Download rendered manifests
+        if: steps.release_state.outputs.release_exists != 'true'
         uses: actions/download-artifact@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -170,9 +186,11 @@ jobs:
           path: artifacts/rendered
 
       - name: Install Cosign
+        if: steps.release_state.outputs.release_exists != 'true'
         uses: sigstore/cosign-installer@v4.1.1
 
       - name: Log in to GHCR
+        if: steps.release_state.outputs.release_exists != 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -181,16 +199,18 @@ jobs:
 
       # Auxiliary release metadata is assembled here because it does not change the shipped bits.
       - name: Publish images and record release metadata
+        if: steps.release_state.outputs.release_exists != 'true'
         env:
           EXPECTED_SERVICES_JSON: ${{ steps.inventory.outputs.containerized }}
         run: |
           scripts/release/publish-images.sh \
             --source artifacts/release-source \
             --release-dir artifacts/release \
-            --version "${{ steps.set_version.outputs.version }}" \
+            --version "${{ steps.release_state.outputs.version }}" \
             --expected-services-json "$EXPECTED_SERVICES_JSON"
 
       - name: Build release manifest
+        if: steps.release_state.outputs.release_exists != 'true'
         env:
           EXPECTED_SERVICES_JSON: ${{ steps.inventory.outputs.containerized }}
           SOURCE_CI_RUN_ID: ${{ steps.source_run.outputs.run_id }}
@@ -199,7 +219,7 @@ jobs:
           scripts/release/build-release-manifest.sh \
             --release-dir artifacts/release \
             --output release-manifest.json \
-            --version "${{ steps.set_version.outputs.version }}" \
+            --version "${{ steps.release_state.outputs.version }}" \
             --commit "${{ env.MERGE_COMMIT_SHA }}" \
             --expected-services-json "$EXPECTED_SERVICES_JSON"
 
@@ -210,10 +230,11 @@ jobs:
           echo "sha256=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Upload release assets
+        if: steps.release_state.outputs.release_exists != 'true'
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ steps.set_version.outputs.version }}
-          name: ${{ steps.set_version.outputs.version }}
+          tag_name: ${{ steps.release_state.outputs.version }}
+          name: ${{ steps.release_state.outputs.version }}
           draft: false
           prerelease: false
           generate_release_notes: true
@@ -268,7 +289,7 @@ jobs:
         run: |
           scripts/release/promote-os-config.py \
             --repo-dir os-config \
-            --version "${{ steps.set_version.outputs.version }}" \
+            --version "${{ steps.release_state.outputs.version }}" \
             --source-repo "${{ github.repository }}" \
             --commit "${{ env.MERGE_COMMIT_SHA }}" \
             --manifest-sha256 "${{ steps.release_manifest.outputs.sha256 }}"
@@ -292,10 +313,10 @@ jobs:
           git -C os-config config user.email "asterism-release[bot]@users.noreply.github.com"
 
           if git -C os-config diff --quiet -- app/asterism/kustomization.yaml; then
-            echo "os-config already points at ${{ steps.set_version.outputs.version }}."
+            echo "os-config already points at ${{ steps.release_state.outputs.version }}."
           else
             git -C os-config add app/asterism/kustomization.yaml
-            git -C os-config commit -m "chore(asterism): promote ${{ steps.set_version.outputs.version }}"
+            git -C os-config commit -m "chore(asterism): promote ${{ steps.release_state.outputs.version }}"
             git -C os-config push origin HEAD:main
           fi
 
@@ -325,7 +346,7 @@ jobs:
             --project "$ARGOCD_PROJECT" \
             --namespace "$ARGOCD_APP_NAMESPACE" \
             --release-manifest release-manifest.json \
-            --release-version "${{ steps.set_version.outputs.version }}" \
+            --release-version "${{ steps.release_state.outputs.version }}" \
             --release-commit "${{ env.MERGE_COMMIT_SHA }}" \
             --manifest-sha256 "${{ steps.release_manifest.outputs.sha256 }}" \
             --os-config-revision "${{ steps.cd_commit.outputs.sha }}"

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -8,6 +8,8 @@ Each GitHub release includes:
 
 The shipped image bytes and rendered manifests are reused from the reviewed PR build. Release publication loads those PR-built image archives, pushes immutable `vX.Y.Z` tags and the moving `latest` deployment tags, signs each immutable image digest, and fails if any expected service is missing an image archive, SBOM, digest, or metadata entry.
 
+Release reruns are idempotent for a merged commit that already has a published release manifest: the workflow reuses that manifest and version instead of minting a second release.
+
 After image publication succeeds, release automation commits the matching Asterism release ref to the separate GitOps repository and adds pod-template annotations that force a rollout while deployments continue to reference `:latest`. Argo CD verification must confirm the app is synced and healthy and that running pod image IDs match the release manifest digests.
 
 The release workflow runs in the GitHub Actions `release` environment. Store release-only credentials there so they are only exposed to the release job.
@@ -42,7 +44,8 @@ Consumers (GitOps automation, audit jobs, or promotion tooling) can parse this f
   - Repository variable: `CD_REPO_GITHUB_APP_ID`
 - Argo CD verification credential:
   - Environment secret: `ARGOCD_AUTH_TOKEN`
-  - The token user must have Argo CD read access to the `apps` project so the verifier can fetch application status and resource trees.
+  - The token user must have Argo CD read and sync access to the `apps` project so the verifier can fetch application status, resource trees, and request a sync when needed.
+  - At minimum, the local Argo CD account should be granted `applications, get` and `applications, sync` on `apps/*`.
 - Repository variables:
   - `CD_REPO_FULL_NAME`, for example `jlfowle/os-config`
   - `ARGOCD_SERVER`

--- a/scripts/release/resolve-release-state.sh
+++ b/scripts/release/resolve-release-state.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: resolve-release-state.sh --repo OWNER/REPO --commit SHA --fallback-version VERSION --manifest-path FILE [--token TOKEN] [--releases-json FILE]
+
+Looks for an existing published GitHub release whose release-manifest.json
+matches the supplied commit. If found, writes that manifest to --manifest-path
+and reports the release version. Otherwise, returns the fallback version.
+EOF
+}
+
+REPO=""
+COMMIT=""
+FALLBACK_VERSION=""
+MANIFEST_PATH=""
+TOKEN="${TOKEN:-}"
+RELEASES_JSON=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --commit)
+      COMMIT="$2"
+      shift 2
+      ;;
+    --fallback-version)
+      FALLBACK_VERSION="$2"
+      shift 2
+      ;;
+    --manifest-path)
+      MANIFEST_PATH="$2"
+      shift 2
+      ;;
+    --token)
+      TOKEN="$2"
+      shift 2
+      ;;
+    --releases-json)
+      RELEASES_JSON="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$REPO" || -z "$COMMIT" || -z "$FALLBACK_VERSION" || -z "$MANIFEST_PATH" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ -z "$RELEASES_JSON" && -z "$TOKEN" ]]; then
+  echo "--token is required unless --releases-json is provided." >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$MANIFEST_PATH")"
+
+download_asset() {
+  local url="$1"
+  local dest="$2"
+
+  case "$url" in
+    file://*)
+      local path="${url#file://}"
+      if [[ -z "$path" ]]; then
+        echo "Release asset URL is missing a local path: $url" >&2
+        return 1
+      fi
+      cp "$path" "$dest"
+      ;;
+    /*)
+      cp "$url" "$dest"
+      ;;
+    *)
+      local headers=(-H "Accept: application/octet-stream" -H "X-GitHub-Api-Version: 2022-11-28")
+      if [[ -n "$TOKEN" ]]; then
+        headers+=(-H "Authorization: Bearer $TOKEN")
+      fi
+      curl -fsSL "${headers[@]}" "$url" -o "$dest"
+      ;;
+  esac
+}
+
+found=0
+resolved_version=""
+resolved_release_tag=""
+resolved_release_url=""
+
+process_release_json() {
+  local release_json="$1"
+
+  if [[ "$(jq -r '.draft // false' <<< "$release_json")" == "true" ]]; then
+    return 0
+  fi
+
+  local asset_url
+  asset_url="$(jq -r '.assets[]? | select(.name == "release-manifest.json") | .browser_download_url' <<< "$release_json" | head -n 1)"
+  if [[ -z "$asset_url" || "$asset_url" == "null" ]]; then
+    return 0
+  fi
+
+  local tmp_manifest
+  tmp_manifest="$(mktemp)"
+  if ! download_asset "$asset_url" "$tmp_manifest"; then
+    rm -f "$tmp_manifest"
+    return 1
+  fi
+
+  local manifest_commit
+  manifest_commit="$(jq -r '.commit // empty' "$tmp_manifest")"
+  if [[ "$manifest_commit" == "$COMMIT" ]]; then
+    resolved_version="$(jq -r '.version // empty' "$tmp_manifest")"
+    if [[ -z "$resolved_version" ]]; then
+      echo "Matched release manifest is missing a version." >&2
+      rm -f "$tmp_manifest"
+      exit 1
+    fi
+
+    resolved_release_tag="$(jq -r '.tag_name // empty' <<< "$release_json")"
+    resolved_release_url="$(jq -r '.html_url // empty' <<< "$release_json")"
+    mv "$tmp_manifest" "$MANIFEST_PATH"
+    found=1
+    return 0
+  fi
+
+  rm -f "$tmp_manifest"
+}
+
+process_release_page() {
+  local page_json="$1"
+  local release_json
+
+  while IFS= read -r release_json; do
+    process_release_json "$release_json"
+    if [[ "$found" -eq 1 ]]; then
+      return 0
+    fi
+  done < <(jq -c '.[]' <<< "$page_json")
+}
+
+if [[ -n "$RELEASES_JSON" ]]; then
+  process_release_page "$(cat "$RELEASES_JSON")"
+else
+  page=1
+  while true; do
+    page_json="$(
+      curl -fsSL \
+        -H "Accept: application/vnd.github+json" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/$REPO/releases?per_page=100&page=$page"
+    )"
+
+    process_release_page "$page_json"
+    if [[ "$found" -eq 1 ]]; then
+      break
+    fi
+
+    if [[ "$(jq 'length' <<< "$page_json")" -lt 100 ]]; then
+      break
+    fi
+
+    page=$((page + 1))
+  done
+fi
+
+if [[ "$found" -eq 1 ]]; then
+  result="$(
+    jq -n \
+      --arg version "$resolved_version" \
+      --arg release_tag "$resolved_release_tag" \
+      --arg release_url "$resolved_release_url" \
+      --argjson release_exists true \
+      '{
+        release_exists: $release_exists,
+        version: $version,
+        release_tag: $release_tag,
+        release_url: $release_url
+      }'
+  )"
+  printf '%s\n' "$result"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "release_exists=true"
+      echo "version=$resolved_version"
+      if [[ -n "$resolved_release_tag" ]]; then
+        echo "release_tag=$resolved_release_tag"
+      fi
+      if [[ -n "$resolved_release_url" ]]; then
+        echo "release_url=$resolved_release_url"
+      fi
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  echo "Reusing existing release $resolved_version for commit $COMMIT." >&2
+else
+  rm -f "$MANIFEST_PATH"
+  result="$(
+    jq -n \
+      --arg version "$FALLBACK_VERSION" \
+      --argjson release_exists false \
+      '{
+        release_exists: $release_exists,
+        version: $version,
+        release_tag: "",
+        release_url: ""
+      }'
+  )"
+  printf '%s\n' "$result"
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "release_exists=false"
+      echo "version=$FALLBACK_VERSION"
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  echo "No existing release found for commit $COMMIT; using $FALLBACK_VERSION." >&2
+fi

--- a/scripts/release/test-release-automation.sh
+++ b/scripts/release/test-release-automation.sh
@@ -64,6 +64,52 @@ if "$SCRIPT_DIR/build-release-manifest.sh" --release-dir "$TMP_DIR" --output "$T
   exit 1
 fi
 
+resolve_dir="$TMP_DIR/resolve"
+mkdir -p "$resolve_dir"
+cat > "$resolve_dir/release-manifest.json" <<'EOF'
+{"version":"v1.2.3","commit":"abcdef0123456789","created":"2026-05-03T00:00:00Z","sourceCiRunId":"42","sourceCiRunUrl":"https://example.invalid/run/42","services":[]}
+EOF
+jq -n \
+  --arg manifest_url "file://$resolve_dir/release-manifest.json" \
+  '[{
+      tag_name: "v1.2.3",
+      html_url: "https://example.invalid/releases/v1.2.3",
+      draft: false,
+      prerelease: false,
+      assets: [
+        {
+          name: "release-manifest.json",
+          browser_download_url: $manifest_url
+        }
+      ]
+    }]' \
+  > "$resolve_dir/releases.json"
+
+resolved_manifest="$TMP_DIR/resolved-release-manifest.json"
+resolved_output="$("$SCRIPT_DIR/resolve-release-state.sh" \
+  --repo jlfowle/asterism \
+  --commit abcdef0123456789 \
+  --fallback-version v9.9.9 \
+  --manifest-path "$resolved_manifest" \
+  --releases-json "$resolve_dir/releases.json")"
+
+echo "$resolved_output" | jq -e '.release_exists == true and .version == "v1.2.3"' > /dev/null
+cmp -s "$resolved_manifest" "$resolve_dir/release-manifest.json"
+
+fallback_manifest="$TMP_DIR/fallback-release-manifest.json"
+fallback_output="$("$SCRIPT_DIR/resolve-release-state.sh" \
+  --repo jlfowle/asterism \
+  --commit feedfacefeedface \
+  --fallback-version v9.9.9 \
+  --manifest-path "$fallback_manifest" \
+  --releases-json "$resolve_dir/releases.json")"
+
+echo "$fallback_output" | jq -e '.release_exists == false and .version == "v9.9.9"' > /dev/null
+if [[ -e "$fallback_manifest" ]]; then
+  echo "resolve-release-state.sh unexpectedly wrote a manifest for a missing release." >&2
+  exit 1
+fi
+
 cd_repo="$TMP_DIR/os-config"
 mkdir -p "$cd_repo/app/asterism"
 cat > "$cd_repo/app/asterism/kustomization.yaml" <<'EOF'
@@ -87,5 +133,19 @@ EOF
 grep -q 'github.com/jlfowle/asterism//deploy?ref=v1.2.3' "$cd_repo/app/asterism/kustomization.yaml"
 grep -q 'asterism.dev~1release-version' "$cd_repo/app/asterism/kustomization.yaml"
 grep -q '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' "$cd_repo/app/asterism/kustomization.yaml"
+
+before_sha="$(sha256sum "$cd_repo/app/asterism/kustomization.yaml" | awk '{print $1}')"
+"$SCRIPT_DIR/promote-os-config.py" \
+  --repo-dir "$cd_repo" \
+  --version v1.2.3 \
+  --source-repo jlfowle/asterism \
+  --commit abcdef0123456789 \
+  --manifest-sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+after_sha="$(sha256sum "$cd_repo/app/asterism/kustomization.yaml" | awk '{print $1}')"
+
+if [[ "$before_sha" != "$after_sha" ]]; then
+  echo "promote-os-config.py changed an already up-to-date overlay." >&2
+  exit 1
+fi
 
 echo "Release automation checks passed."


### PR DESCRIPTION
## What changed
- Added release-state resolution so a rerun for the same merged commit reuses the already-published release manifest and version instead of minting a second release.
- Skips the image publish, manifest build, upload, and release promotion path when a published release already exists.
- Kept the GitOps promotion flow idempotent and updated the release contract to document the rerun behavior.
- Added a shell-based test helper plus coverage for the existing-release and fallback paths.

## Why
A release rerun for the same merge commit should not create duplicate release artifacts or drift the published version when the artifacts already exist.

## Validation
- `bash -n scripts/release/*.sh`
- `bash scripts/release/test-release-automation.sh`
- `git diff --check`

## Notes
This change is focused on the Asterism release workflow and release contract only.