### PR TITLE
fix(release): remove manual Argo CD sync

### DIFF
--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -10,7 +10,7 @@ The shipped image bytes and rendered manifests are reused from the reviewed PR b
 
 Release reruns are idempotent for a merged commit that already has a published release manifest: the workflow reuses that manifest and version instead of minting a second release.
 
-After image publication succeeds, release automation commits the matching Asterism release ref to the separate GitOps repository and adds pod-template annotations that force a rollout while deployments continue to reference `:latest`. Argo CD verification must confirm the app is synced and healthy and that running pod image IDs match the release manifest digests.
+After image publication succeeds, release automation commits the matching Asterism release ref to the separate GitOps repository and adds pod-template annotations that force a rollout while deployments continue to reference `:latest`. Argo CD auto-syncs from the GitOps change via its webhook path, and verification polls until the app is synced and healthy and the running pod image IDs match the release manifest digests.
 
 The release workflow runs in the GitHub Actions `release` environment. Store release-only credentials there so they are only exposed to the release job.
 
@@ -44,8 +44,8 @@ Consumers (GitOps automation, audit jobs, or promotion tooling) can parse this f
   - Repository variable: `CD_REPO_GITHUB_APP_ID`
 - Argo CD verification credential:
   - Environment secret: `ARGOCD_AUTH_TOKEN`
-  - The token user must have Argo CD read and sync access to the `apps` project so the verifier can fetch application status, resource trees, and request a sync when needed.
-  - At minimum, the local Argo CD account should be granted `applications, get` and `applications, sync` on `apps/*`.
+  - The token user must have Argo CD read access to the `apps` project so the verifier can fetch application status and resource trees.
+  - At minimum, the local Argo CD account should be granted `applications, get` on `apps/*`.
 - Repository variables:
   - `CD_REPO_FULL_NAME`, for example `jlfowle/os-config`
   - `ARGOCD_SERVER`

--- a/scripts/release/verify-argocd-deployment.py
+++ b/scripts/release/verify-argocd-deployment.py
@@ -71,17 +71,6 @@ class ArgoClient:
             params["refresh"] = refresh
         return self.request("GET", f"/api/v1/applications/{urllib.parse.quote(app, safe='')}", params=params)
 
-    def sync_application(self, app, project="", revision=""):
-        body = {"prune": False, "dryRun": False}
-        if revision:
-            body["revision"] = revision
-        return self.request(
-            "POST",
-            f"/api/v1/applications/{urllib.parse.quote(app, safe='')}/sync",
-            params={"project": project},
-            body=body,
-        )
-
     def resource_tree(self, app, project=""):
         return self.request(
             "GET",
@@ -185,9 +174,8 @@ def deployment_ready(deployment):
     return False, f"{name} is not Available"
 
 
-def evaluate(client, args, expected_services):
+def evaluate(client, args, expected_services, app):
     reasons = []
-    app = client.get_application(args.app, args.project)
     namespace = args.namespace or app.get("spec", {}).get("destination", {}).get("namespace", "")
 
     if not namespace:
@@ -271,23 +259,12 @@ def main():
     client = ArgoClient(args.server, args.token)
 
     print(f"Refreshing Argo CD application {args.app}.")
-    client.get_application(args.app, args.project, refresh="hard")
-
-    try:
-        print(f"Requesting Argo CD sync for {args.app} at revision {args.os_config_revision}.")
-        client.sync_application(args.app, args.project, args.os_config_revision)
-    except RuntimeError as error:
-        text = str(error).lower()
-        if "another operation" in text or "operation is already in progress" in text:
-            print(f"Argo CD already has an operation in progress: {error}")
-        else:
-            raise
-
     deadline = time.monotonic() + args.timeout_seconds
     last_reasons = []
 
     while time.monotonic() < deadline:
-        ok, reasons = evaluate(client, args, expected_services)
+        app = client.get_application(args.app, args.project, refresh="hard")
+        ok, reasons = evaluate(client, args, expected_services, app)
         if ok:
             print("Argo CD deployment verification succeeded.")
             return

--- a/scripts/release/verify-argocd-deployment.py
+++ b/scripts/release/verify-argocd-deployment.py
@@ -137,6 +137,19 @@ def app_revision(app):
     return sync.get("revision") or sync_result.get("revision") or ""
 
 
+def app_has_revision(app, revision):
+    if not revision:
+        return False
+    if app_revision(app) == revision:
+        return True
+
+    for entry in app.get("status", {}).get("history", []):
+        if entry.get("revision") == revision:
+            return True
+
+    return False
+
+
 def pod_digest_matches(pod, service, expected):
     statuses = pod.get("status", {}).get("containerStatuses", [])
     for status in statuses:
@@ -186,8 +199,10 @@ def evaluate(client, args, expected_services, app):
     sync_status = app.get("status", {}).get("sync", {}).get("status", "")
     health_status = app.get("status", {}).get("health", {}).get("status", "")
 
-    if revision != args.os_config_revision:
-        reasons.append(f"Argo CD revision is {revision or '<empty>'}, expected {args.os_config_revision}.")
+    if not app_has_revision(app, args.os_config_revision):
+        reasons.append(
+            f"Argo CD has not reported revision {args.os_config_revision} yet; current revision is {revision or '<empty>'}."
+        )
     if sync_status != "Synced":
         reasons.append(f"Argo CD sync status is {sync_status or '<empty>'}, expected Synced.")
     if health_status != "Healthy":


### PR DESCRIPTION
## What changed
- Removed the release verifier's explicit Argo CD sync request.
- Kept verification on the polling path: refresh the application, wait for Synced/Healthy, and confirm the running pod digests match the release manifest.
- Updated the release contract to say Argo CD auto-syncs from the GitOps change via its webhook path.
- Removed the no-longer-needed `applications, sync` permission from `os-config` and pushed that cleanup directly to `main`.

## Why
Argo CD already auto-syncs when `os-config` changes, so the release job should not duplicate that behavior or require sync RBAC just to finish verification.

## Validation
- `python3 -m py_compile scripts/release/verify-argocd-deployment.py`
- `git diff --check`

## Notes
- `os-config` was updated directly on `main` as requested.
- The release verifier still confirms the application reaches Synced/Healthy before declaring success.