### PR TITLE
feat: add operator cockpit observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ Home control center platform using microservices (Go), a runtime-composed microf
 
 ## Services
 - `polaris`: host shell UI and runtime microfrontend registry client.
-- `unifi`: UniFi integration service scaffold.
-- `cluster`: OpenShift integration service scaffold.
-- `pfsense`: pfSense integration service scaffold.
+- `unifi`: read-only UniFi Network status from the local Network API.
+- `cluster`: read-only OpenShift and Argo CD status from least-privilege cluster APIs.
+- `pfsense`: read-only pfSense gateway status through SNMP.
+
+## Operator Cockpit Direction
+- Asterism is an approachable operations layer for people who should not need to be experts in UniFi, pfSense, OpenShift, or Argo CD.
+- Backend systems remain the authorities for their own configuration.
+- Asterism exposes status, plain-language diagnostics, authoritative links, and guided action contracts without storing shadow configuration.
+- Mutating controls are intentionally disabled until they can be implemented as narrow, audited, backend-owned actions.
 
 ## Local Development
 1. `make dev`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,13 @@ This document summarizes the current platform direction. Repository-wide behavio
 - Polaris is the runtime shell and layout orchestrator for service-owned microfrontend modules.
 - OpenShift-native deployment with Kustomize and GitOps pull from a separate GitOps repository.
 - One deployed environment, promoted from `main`, consuming `latest` tags from successful `main` builds.
+- Asterism is an operator cockpit rather than a replacement configuration authority for backend systems.
+
+## Operator Cockpit Boundary
+- Asterism may expose backend-owned status, plain-language diagnostics, authoritative links, audit-ready action contracts, and future automation entrypoints.
+- Asterism must not duplicate broad UniFi, pfSense, OpenShift, or Argo CD configuration state.
+- User-facing controls should be intent-based and narrowly scoped, for example "restart this approved access point" or "sync this Argo CD application", not arbitrary backend config editing.
+- The first implementation milestone is observe-first: guided actions are advertised as disabled contracts until mutating paths are explicitly designed and approved.
 
 ## Repository Layout
 - `services/polaris`: host shell microfrontend canvas.
@@ -30,11 +37,11 @@ This keeps contracts with implementation ownership and supports separate lifecyc
 - UI actions should interact through documented service APIs rather than bypassing backend contracts.
 - Public service APIs are routed under `/api/services/{service}/...`; service-owned UI assets are routed under `/ui/services/{service}/...`.
 
-## Initial Integration Probes
-- `unifi`: probes `UNIFI_API_URL` with optional `UNIFI_API_TOKEN`.
-- `cluster`: probes `CLUSTER_API_URL` using in-cluster service account token and CA.
-- `pfsense`: probes `PFSENSE_API_URL` with optional `PFSENSE_API_TOKEN`.
-- Probe output is returned in `/api/v1/status.integration` for dashboard consumption.
+## Operator Summaries
+- `unifi`: reads local UniFi Network API device and client status from `UNIFI_API_BASE_URL`, `UNIFI_SITE_ID`, and `UNIFI_API_TOKEN`.
+- `cluster`: reads Kubernetes, OpenShift, and Argo CD status from `CLUSTER_API_URL` using a dedicated read-only service account.
+- `pfsense`: reads pfSense system and interface status with read-only SNMP using `PFSENSE_SNMP_HOST` and `PFSENSE_SNMP_COMMUNITY`.
+- Service output is returned in `/api/v1/status.integration`, mirrored by `/api/v1/summary`, and includes severity, degraded reasons, recommended actions, authoritative links, and disabled guided action contracts.
 
 ## Security Model
 - External user authentication is delegated through Cognito OIDC.
@@ -42,6 +49,7 @@ This keeps contracts with implementation ownership and supports separate lifecyc
 - Internal service-to-service authentication and authorization are delegated to the service mesh using mTLS and mesh policy.
 - Secret material is sourced from AWS Secrets Manager through External Secrets Operator.
 - Protected service endpoints (`/api/v1/status`) require identity context by default (`AUTH_MODE=enforced`) and read forwarded principal/group headers (`X-Asterism-Principal`, `X-Asterism-Groups`).
+- Polaris supports runtime-configured Cognito OIDC sign-in with Authorization Code + PKCE and sends bearer tokens to protected service APIs when configured.
 - External traffic enters through `https://asterism.apps.os.fowler.house/` and is routed by Service Mesh Gateway API resources rather than direct per-service OpenShift Routes.
 
 ## CI/CD And Supply Chain

--- a/docs/deploy-standards.md
+++ b/docs/deploy-standards.md
@@ -81,6 +81,12 @@ runtime secret dependency.
 - Auto-refresh interval: 1 hour
 - Include this file only when the service has sensitive runtime data that must
   be delivered through the secret manager
+- The platform/GitOps layer must provide `ClusterSecretStore/aws-secretsmanager`; service manifests reference it but do not define cloud credentials.
+
+Current service secret shapes:
+
+- `/asterism/unifi`: `apiBaseUrl`, `apiToken`, optional `siteId`, optional `consoleUrl`
+- `/asterism/pfsense`: `snmpHost`, `snmpCommunity`, optional `snmpPort`, optional `consoleUrl`, optional `expectedUpInterfaces`
 
 ### Public Routing Standard
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,6 +25,12 @@ The local run mode disables application auth and leaves integration endpoints
 unset unless you override them, which keeps the stack usable without cloud or
 home-network credentials.
 
+The default local integrations report "not configured". To test real read-only upstreams, set:
+
+- `UNIFI_API_BASE_URL`, `UNIFI_API_TOKEN`, and optionally `UNIFI_SITE_ID`
+- `PFSENSE_SNMP_HOST`, `PFSENSE_SNMP_COMMUNITY`, and optionally `PFSENSE_EXPECTED_UP_INTERFACES`
+- `CLUSTER_API_URL` when running the Cluster service with an available service account token and CA
+
 ## Common Commands
 
 - `make test` runs the service test suite for all services.
@@ -52,6 +58,8 @@ Each service owns its implementation, contracts, and deploy manifests:
 - `services/{service}/api/openapi.yaml`
 - `services/{service}/api/asyncapi.yaml`
 - `services/{service}/deploy/kustomization.yaml`
+
+Integration services expose `/api/v1/status`, `/api/v1/summary`, and `/api/v1/actions`. The action endpoint is a read-only contract catalog; it does not mutate backend systems.
 
 Local Polaris proxies match the deployed public routing standard:
 

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -13,6 +13,7 @@ These standards apply to both human contributors and AI agents working in Asteri
 - Services may contribute UI resources, but Polaris remains the composition layer that discovers and renders them.
 - Frontend behavior should consume backend APIs rather than re-implement service logic in the browser.
 - Public traffic enters through the single Asterism host and Gateway API routing. Services expose internal APIs under `/api/v1/*` and service-owned UI assets under `/ui/*`; public paths are composed as `/api/services/{service}/...` and `/ui/services/{service}/...`.
+- Asterism should expose approachable status, diagnostics, and narrow guided controls without replacing backend systems as the source of truth for their own configuration.
 
 ## 3. API-First Contract Model
 - API-first is mandatory for every service.

--- a/scripts/dev-platform.sh
+++ b/scripts/dev-platform.sh
@@ -34,9 +34,9 @@ start_service() {
 
 trap cleanup EXIT INT TERM
 
-start_service unifi PORT=8081 AUTH_MODE=disabled UNIFI_API_URL=
+start_service unifi PORT=8081 AUTH_MODE=disabled UNIFI_API_BASE_URL= UNIFI_SITE_ID=default
 start_service cluster PORT=8082 AUTH_MODE=disabled CLUSTER_API_URL=
-start_service pfsense PORT=8083 AUTH_MODE=disabled PFSENSE_API_URL=
+start_service pfsense PORT=8083 AUTH_MODE=disabled PFSENSE_SNMP_HOST= PFSENSE_SNMP_COMMUNITY=
 start_service polaris
 
 printf '%s\n' 'Local platform is running.'

--- a/services/cluster/api/openapi.yaml
+++ b/services/cluster/api/openapi.yaml
@@ -10,6 +10,72 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  schemas:
+    GuidedAction:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        description:
+          type: string
+        risk:
+          type: string
+        enabled:
+          type: boolean
+        requiresApproval:
+          type: boolean
+        auditEvent:
+          type: string
+    IntegrationSnapshot:
+      type: object
+      properties:
+        configured:
+          type: boolean
+        reachable:
+          type: boolean
+        endpoint:
+          type: string
+        message:
+          type: string
+        httpStatus:
+          type: integer
+        latencyMs:
+          type: integer
+        observedAt:
+          type: string
+          format: date-time
+        severity:
+          type: string
+          enum: [ok, warning, critical, unknown]
+        degradedReasons:
+          type: array
+          items:
+            type: string
+        recommendedActions:
+          type: array
+          items:
+            type: string
+        authoritativeLinks:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              href:
+                type: string
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GuidedAction'
+        metrics:
+          type: object
+          additionalProperties: true
+        summary:
+          type: object
+          additionalProperties: true
 paths:
   /healthz:
     get:
@@ -37,23 +103,64 @@ paths:
                   principal:
                     type: string
                   integration:
-                    type: object
-                    properties:
-                      configured:
-                        type: boolean
-                      reachable:
-                        type: boolean
-                      endpoint:
-                        type: string
-                      message:
-                        type: string
-                      httpStatus:
-                        type: integer
-                      latencyMs:
-                        type: integer
-                      metrics:
-                        type: object
-                        additionalProperties: true
+                    $ref: '#/components/schemas/IntegrationSnapshot'
+                  timestamp:
+                    type: string
+                    format: date-time
+        '401':
+          description: Missing identity context
+        '403':
+          description: Authenticated but not authorized
+  /api/v1/summary:
+    get:
+      summary: Return read-only OpenShift and GitOps operator summary
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current operator summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  status:
+                    type: string
+                  principal:
+                    type: string
+                  integration:
+                    $ref: '#/components/schemas/IntegrationSnapshot'
+                  timestamp:
+                    type: string
+                    format: date-time
+        '401':
+          description: Missing identity context
+        '403':
+          description: Authenticated but not authorized
+  /api/v1/actions:
+    get:
+      summary: Return available guided action contracts
+      description: Actions are advertised for UX and automation planning only; this endpoint does not mutate OpenShift or Argo CD.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Guided action catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  principal:
+                    type: string
+                  actions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/GuidedAction'
                   timestamp:
                     type: string
                     format: date-time

--- a/services/cluster/deploy/base/deployment.yaml
+++ b/services/cluster/deploy/base/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
     spec:
+      serviceAccountName: cluster
       containers:
         - name: cluster
           image: cluster
@@ -31,6 +32,10 @@ spec:
               value: ""
             - name: CLUSTER_API_URL
               value: "https://kubernetes.default.svc/version"
+            - name: CLUSTER_CONSOLE_URL
+              value: ""
+            - name: ARGOCD_CONSOLE_URL
+              value: ""
           livenessProbe:
             httpGet:
               path: /healthz

--- a/services/cluster/deploy/base/rbac.yaml
+++ b/services/cluster/deploy/base/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: asterism-cluster-readonly
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces", "pods", "services"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["config.openshift.io"]
+    resources: ["clusterversions", "clusteroperators"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: asterism-cluster-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: asterism-cluster-readonly
+subjects:
+  - kind: ServiceAccount
+    name: cluster
+    namespace: asterism

--- a/services/cluster/deploy/base/serviceaccount.yaml
+++ b/services/cluster/deploy/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster
+automountServiceAccountToken: true

--- a/services/cluster/deploy/kustomization.yaml
+++ b/services/cluster/deploy/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: asterism
 resources:
   - ./base/deployment.yaml
   - ./base/service.yaml
+  - ./base/serviceaccount.yaml
+  - ./base/rbac.yaml
 images:
   - name: cluster
     newName: ghcr.io/jlfowle/asterism-cluster

--- a/services/cluster/internal/api/handlers.go
+++ b/services/cluster/internal/api/handlers.go
@@ -33,6 +33,8 @@ func (h Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(http.FS(uiassets.Files))))
 	mux.HandleFunc("/healthz", h.healthz)
 	mux.Handle("/api/v1/status", h.auth.Protect(http.HandlerFunc(h.status)))
+	mux.Handle("/api/v1/summary", h.auth.Protect(http.HandlerFunc(h.status)))
+	mux.Handle("/api/v1/actions", h.auth.Protect(http.HandlerFunc(h.actions)))
 }
 
 func (h Handler) healthz(w http.ResponseWriter, _ *http.Request) {
@@ -48,6 +50,24 @@ func (h Handler) status(w http.ResponseWriter, r *http.Request) {
 		Principal:   principalFromContext(r.Context()),
 		Integration: integration.Probe(r.Context()),
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h Handler) actions(w http.ResponseWriter, r *http.Request) {
+	resp := struct {
+		Service   string                `json:"service"`
+		Principal string                `json:"principal,omitempty"`
+		Actions   []integration.Control `json:"actions"`
+		Timestamp string                `json:"timestamp"`
+	}{
+		Service:   h.serviceName,
+		Principal: principalFromContext(r.Context()),
+		Actions:   integration.Actions(),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/services/cluster/internal/api/handlers_test.go
+++ b/services/cluster/internal/api/handlers_test.go
@@ -13,6 +13,14 @@ type statusTestResponse struct {
 	Principal string `json:"principal"`
 }
 
+type actionsTestResponse struct {
+	Service string `json:"service"`
+	Actions []struct {
+		ID      string `json:"id"`
+		Enabled bool   `json:"enabled"`
+	} `json:"actions"`
+}
+
 func TestHealthz(t *testing.T) {
 	h := NewHandler("cluster")
 	mux := http.NewServeMux()
@@ -104,5 +112,39 @@ func TestStatusAuthorizedWithPrincipal(t *testing.T) {
 
 	if payload.Principal != "test-user" {
 		t.Fatalf("expected principal %q, got %q", "test-user", payload.Principal)
+	}
+}
+
+func TestActionsAuthorizedWithPrincipal(t *testing.T) {
+	t.Setenv("AUTH_MODE", "enforced")
+	t.Setenv("AUTH_REQUIRED_GROUP", "")
+
+	h := NewHandler("cluster")
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil)
+	req.Header.Set("X-Asterism-Principal", "test-user")
+
+	res := httptest.NewRecorder()
+	mux.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+
+	var payload actionsTestResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to unmarshal actions response: %v", err)
+	}
+
+	if payload.Service != "cluster" {
+		t.Fatalf("expected service %q, got %q", "cluster", payload.Service)
+	}
+	if len(payload.Actions) == 0 {
+		t.Fatalf("expected guided action contracts")
+	}
+	if payload.Actions[0].Enabled {
+		t.Fatalf("expected guided actions to be disabled in observe-first milestone")
 	}
 }

--- a/services/cluster/internal/integration/probe.go
+++ b/services/cluster/internal/integration/probe.go
@@ -9,18 +9,64 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
 type Snapshot struct {
-	Configured bool   `json:"configured"`
-	Reachable  bool   `json:"reachable"`
-	Endpoint   string `json:"endpoint,omitempty"`
-	Message    string `json:"message"`
-	HTTPStatus int    `json:"httpStatus,omitempty"`
-	LatencyMs  int64  `json:"latencyMs,omitempty"`
-	Metrics    any    `json:"metrics,omitempty"`
+	Configured         bool      `json:"configured"`
+	Reachable          bool      `json:"reachable"`
+	Endpoint           string    `json:"endpoint,omitempty"`
+	Message            string    `json:"message"`
+	HTTPStatus         int       `json:"httpStatus,omitempty"`
+	LatencyMs          int64     `json:"latencyMs,omitempty"`
+	ObservedAt         string    `json:"observedAt"`
+	Severity           string    `json:"severity"`
+	DegradedReasons    []string  `json:"degradedReasons,omitempty"`
+	RecommendedActions []string  `json:"recommendedActions,omitempty"`
+	AuthoritativeLinks []Link    `json:"authoritativeLinks,omitempty"`
+	Controls           []Control `json:"controls,omitempty"`
+	Metrics            any       `json:"metrics,omitempty"`
+	Summary            Summary   `json:"summary,omitempty"`
+}
+
+type Summary struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Stats       []Stat   `json:"stats,omitempty"`
+	Highlights  []string `json:"highlights,omitempty"`
+}
+
+type Stat struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+	Unit  string `json:"unit,omitempty"`
+	State string `json:"state,omitempty"`
+}
+
+type Link struct {
+	Label string `json:"label"`
+	Href  string `json:"href"`
+}
+
+type Control struct {
+	ID               string `json:"id"`
+	Label            string `json:"label"`
+	Description      string `json:"description"`
+	Risk             string `json:"risk"`
+	Enabled          bool   `json:"enabled"`
+	RequiresApproval bool   `json:"requiresApproval"`
+	AuditEvent       string `json:"auditEvent"`
+}
+
+type Config struct {
+	Endpoint   string
+	Token      string
+	TokenPath  string
+	CAPath     string
+	ConsoleURL string
+	ArgoCDURL  string
 }
 
 type versionPayload struct {
@@ -33,6 +79,9 @@ type listPayload struct {
 
 type nodeListPayload struct {
 	Items []struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
 		Status struct {
 			Conditions []struct {
 				Type   string `json:"type"`
@@ -42,43 +91,143 @@ type nodeListPayload struct {
 	} `json:"items"`
 }
 
+type deploymentListPayload struct {
+	Items []struct {
+		Status struct {
+			Replicas          int `json:"replicas"`
+			AvailableReplicas int `json:"availableReplicas"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+type podListPayload struct {
+	Items []struct {
+		Status struct {
+			Phase string `json:"phase"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+type clusterVersionListPayload struct {
+	Items []struct {
+		Status struct {
+			Desired struct {
+				Version string `json:"version"`
+			} `json:"desired"`
+			Conditions []struct {
+				Type    string `json:"type"`
+				Status  string `json:"status"`
+				Message string `json:"message"`
+			} `json:"conditions"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+type clusterOperatorListPayload struct {
+	Items []struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Status struct {
+			Conditions []struct {
+				Type    string `json:"type"`
+				Status  string `json:"status"`
+				Message string `json:"message"`
+			} `json:"conditions"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
+type argoApplicationListPayload struct {
+	Items []struct {
+		Metadata struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+		Status struct {
+			Health struct {
+				Status string `json:"status"`
+			} `json:"health"`
+			Sync struct {
+				Status string `json:"status"`
+			} `json:"sync"`
+		} `json:"status"`
+	} `json:"items"`
+}
+
 func Probe(ctx context.Context) Snapshot {
-	endpoint := strings.TrimSpace(os.Getenv("CLUSTER_API_URL"))
-	if endpoint == "" {
+	return ProbeWithConfig(ctx, ConfigFromEnv())
+}
+
+func ConfigFromEnv() Config {
+	return Config{
+		Endpoint:   strings.TrimSpace(os.Getenv("CLUSTER_API_URL")),
+		TokenPath:  firstNonEmpty(os.Getenv("CLUSTER_SERVICEACCOUNT_TOKEN_PATH"), "/var/run/secrets/kubernetes.io/serviceaccount/token"),
+		CAPath:     firstNonEmpty(os.Getenv("CLUSTER_SERVICEACCOUNT_CA_PATH"), "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"),
+		ConsoleURL: strings.TrimSpace(os.Getenv("CLUSTER_CONSOLE_URL")),
+		ArgoCDURL:  strings.TrimSpace(os.Getenv("ARGOCD_CONSOLE_URL")),
+	}
+}
+
+func ProbeWithConfig(ctx context.Context, cfg Config) Snapshot {
+	observedAt := time.Now().UTC().Format(time.RFC3339)
+	if cfg.Endpoint == "" {
 		return Snapshot{
-			Configured: false,
-			Reachable:  false,
-			Message:    "integration not configured",
+			Configured:         false,
+			Reachable:          false,
+			Message:            "OpenShift API monitoring is not configured yet.",
+			ObservedAt:         observedAt,
+			Severity:           "unknown",
+			RecommendedActions: []string{"Set CLUSTER_API_URL to the in-cluster Kubernetes API version endpoint."},
+			Controls:           Actions(),
+			Summary: Summary{
+				Title:       "OpenShift needs connection details",
+				Description: "Asterism can explain cluster and GitOps health after the API endpoint is configured.",
+			},
 		}
 	}
 
-	apiRoot, versionURL, parseErr := deriveURLs(endpoint)
+	apiRoot, versionURL, parseErr := deriveURLs(cfg.Endpoint)
 	if parseErr != nil {
 		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("invalid cluster endpoint: %v", parseErr),
+			Configured:         true,
+			Reachable:          false,
+			Endpoint:           cfg.Endpoint,
+			Message:            fmt.Sprintf("Invalid OpenShift endpoint: %v", parseErr),
+			ObservedAt:         observedAt,
+			Severity:           "critical",
+			RecommendedActions: []string{"Use a full https URL for CLUSTER_API_URL."},
+			Controls:           Actions(),
 		}
 	}
 
-	tokenBytes, tokenErr := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	tokenBytes, tokenErr := tokenBytes(cfg)
 	if tokenErr != nil {
 		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("missing service account token: %v", tokenErr),
+			Configured:         true,
+			Reachable:          false,
+			Endpoint:           cfg.Endpoint,
+			Message:            fmt.Sprintf("Missing service account token: %v", tokenErr),
+			ObservedAt:         observedAt,
+			Severity:           "critical",
+			DegradedReasons:    []string{"The Cluster service cannot authenticate to the Kubernetes API."},
+			RecommendedActions: []string{"Verify the dedicated cluster service account is mounted into the pod."},
+			Controls:           Actions(),
 		}
 	}
 
-	caPool, caErr := readClusterCA()
+	caPool, caErr := readClusterCA(cfg)
 	if caErr != nil {
 		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("invalid cluster CA: %v", caErr),
+			Configured:         true,
+			Reachable:          false,
+			Endpoint:           cfg.Endpoint,
+			Message:            fmt.Sprintf("Invalid OpenShift API CA: %v", caErr),
+			ObservedAt:         observedAt,
+			Severity:           "critical",
+			DegradedReasons:    []string{"The Cluster service cannot validate the Kubernetes API certificate."},
+			RecommendedActions: []string{"Verify the service account CA bundle is mounted into the pod."},
+			Controls:           Actions(),
 		}
 	}
 
@@ -94,17 +243,32 @@ func Probe(ctx context.Context) Snapshot {
 	latencyMs := time.Since(startedAt).Milliseconds()
 	if requestErr != nil {
 		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("request failed: %v", requestErr),
-			HTTPStatus: statusCode,
-			LatencyMs:  latencyMs,
+			Configured:         true,
+			Reachable:          false,
+			Endpoint:           cfg.Endpoint,
+			Message:            fmt.Sprintf("OpenShift API request failed: %v", requestErr),
+			HTTPStatus:         statusCode,
+			LatencyMs:          latencyMs,
+			ObservedAt:         observedAt,
+			Severity:           "critical",
+			DegradedReasons:    []string{"Asterism could not read the OpenShift API version."},
+			RecommendedActions: []string{"Confirm the in-cluster API endpoint and service account RBAC."},
+			AuthoritativeLinks: authoritativeLinks(cfg),
+			Controls:           Actions(),
+			Summary: Summary{
+				Title:       "OpenShift API is unreachable",
+				Description: "Cluster status is unavailable until the Kubernetes API responds.",
+			},
 		}
 	}
 
 	nodeResp, _, nodesErr := getJSON[nodeListPayload](ctx, client, apiRoot+"/api/v1/nodes", tokenBytes)
-	podResp, _, podsErr := getJSON[listPayload](ctx, client, apiRoot+"/api/v1/pods", tokenBytes)
+	podResp, _, podsErr := getJSON[podListPayload](ctx, client, apiRoot+"/api/v1/pods", tokenBytes)
+	namespaceResp, _, namespaceErr := getJSON[listPayload](ctx, client, apiRoot+"/api/v1/namespaces", tokenBytes)
+	deploymentResp, _, deploymentsErr := getJSON[deploymentListPayload](ctx, client, apiRoot+"/apis/apps/v1/deployments", tokenBytes)
+	clusterVersionResp, _, clusterVersionErr := getJSON[clusterVersionListPayload](ctx, client, apiRoot+"/apis/config.openshift.io/v1/clusterversions", tokenBytes)
+	operatorResp, _, operatorsErr := getJSON[clusterOperatorListPayload](ctx, client, apiRoot+"/apis/config.openshift.io/v1/clusteroperators", tokenBytes)
+	appResp, _, appsErr := getJSON[argoApplicationListPayload](ctx, client, apiRoot+"/apis/argoproj.io/v1alpha1/namespaces/openshift-gitops/applications", tokenBytes)
 
 	healthyNodes := 0
 	for _, node := range nodeResp.Items {
@@ -115,36 +279,112 @@ func Probe(ctx context.Context) Snapshot {
 			}
 		}
 	}
+	runningPods, unhealthyPods := podPhaseCounts(podResp)
+	availableDeployments, totalDeploymentReplicas := deploymentCounts(deploymentResp)
+	operatorIssues := operatorIssueCount(operatorResp)
+	appIssues := applicationIssueCount(appResp)
+	clusterVersion := versionResp.GitVersion
+	if len(clusterVersionResp.Items) > 0 && clusterVersionResp.Items[0].Status.Desired.Version != "" {
+		clusterVersion = clusterVersionResp.Items[0].Status.Desired.Version
+	}
+	reasons := degradedReasons(nodeResp, healthyNodes, unhealthyPods, availableDeployments, totalDeploymentReplicas, deploymentsErr, operatorIssues, appsErr, appIssues, nodesErr, podsErr, operatorsErr)
+	severity := "ok"
+	message := "OpenShift API is reachable."
+	if len(reasons) > 0 {
+		severity = "warning"
+		message = "OpenShift API is reachable with items to review."
+	}
 
 	metrics := map[string]any{
-		"clusterVersion":    versionResp.GitVersion,
-		"nodeCount":         len(nodeResp.Items),
-		"readyNodeCount":    healthyNodes,
-		"podCount":          len(podResp.Items),
-		"nodesFetchSuccess": nodesErr == nil,
-		"podsFetchSuccess":  podsErr == nil,
+		"clusterVersion":               clusterVersion,
+		"nodeCount":                    len(nodeResp.Items),
+		"readyNodeCount":               healthyNodes,
+		"namespaceCount":               len(namespaceResp.Items),
+		"podCount":                     len(podResp.Items),
+		"runningPodCount":              runningPods,
+		"unhealthyPodCount":            unhealthyPods,
+		"deploymentCount":              len(deploymentResp.Items),
+		"availableDeploymentReplicas":  availableDeployments,
+		"desiredDeploymentReplicas":    totalDeploymentReplicas,
+		"clusterOperatorCount":         len(operatorResp.Items),
+		"clusterOperatorIssueCount":    operatorIssues,
+		"argoApplicationCount":         len(appResp.Items),
+		"argoApplicationIssueCount":    appIssues,
+		"nodesFetchSuccess":            nodesErr == nil,
+		"podsFetchSuccess":             podsErr == nil,
+		"namespacesFetchSuccess":       namespaceErr == nil,
+		"deploymentsFetchSuccess":      deploymentsErr == nil,
+		"clusterVersionFetchSuccess":   clusterVersionErr == nil,
+		"operatorsFetchSuccess":        operatorsErr == nil,
+		"argoApplicationsFetchSuccess": appsErr == nil,
 	}
 
 	if statusCode >= 200 && statusCode < 400 {
 		return Snapshot{
-			Configured: true,
-			Reachable:  true,
-			Endpoint:   endpoint,
-			Message:    "cluster API reachable",
-			HTTPStatus: statusCode,
-			LatencyMs:  latencyMs,
-			Metrics:    metrics,
+			Configured:         true,
+			Reachable:          true,
+			Endpoint:           cfg.Endpoint,
+			Message:            message,
+			HTTPStatus:         statusCode,
+			LatencyMs:          latencyMs,
+			ObservedAt:         observedAt,
+			Severity:           severity,
+			DegradedReasons:    reasons,
+			RecommendedActions: recommendedActions(reasons),
+			AuthoritativeLinks: authoritativeLinks(cfg),
+			Controls:           Actions(),
+			Metrics:            metrics,
+			Summary: Summary{
+				Title:       "OpenShift and GitOps overview",
+				Description: "Read-only status from the Kubernetes, OpenShift, and Argo CD APIs.",
+				Stats: []Stat{
+					{Label: "Nodes ready", Value: fmt.Sprintf("%d/%d", healthyNodes, len(nodeResp.Items)), State: stateForEquality(healthyNodes, len(nodeResp.Items))},
+					{Label: "Pods running", Value: fmt.Sprintf("%d/%d", runningPods, len(podResp.Items)), State: stateForZero(unhealthyPods)},
+					{Label: "Operators to review", Value: strconv.Itoa(operatorIssues), State: stateForZero(operatorIssues)},
+					{Label: "GitOps apps to review", Value: strconv.Itoa(appIssues), State: stateForZero(appIssues)},
+				},
+				Highlights: highlights(clusterVersion, healthyNodes, len(nodeResp.Items), appResp, appsErr),
+			},
 		}
 	}
 
 	return Snapshot{
-		Configured: true,
-		Reachable:  false,
-		Endpoint:   endpoint,
-		Message:    fmt.Sprintf("cluster API returned status %d", statusCode),
-		HTTPStatus: statusCode,
-		LatencyMs:  latencyMs,
-		Metrics:    metrics,
+		Configured:         true,
+		Reachable:          false,
+		Endpoint:           cfg.Endpoint,
+		Message:            fmt.Sprintf("OpenShift API returned status %d", statusCode),
+		HTTPStatus:         statusCode,
+		LatencyMs:          latencyMs,
+		ObservedAt:         observedAt,
+		Severity:           "critical",
+		DegradedReasons:    []string{"The OpenShift API version endpoint returned an unsuccessful response."},
+		RecommendedActions: []string{"Confirm the API endpoint and service account permissions."},
+		AuthoritativeLinks: authoritativeLinks(cfg),
+		Controls:           Actions(),
+		Metrics:            metrics,
+	}
+}
+
+func Actions() []Control {
+	return []Control{
+		{
+			ID:               "cluster.sync-argocd-application",
+			Label:            "Sync Argo CD application",
+			Description:      "Future guided action that would ask Argo CD to sync a selected application after confirmation.",
+			Risk:             "medium",
+			Enabled:          false,
+			RequiresApproval: true,
+			AuditEvent:       "cluster.guided_action.sync_argocd_application",
+		},
+		{
+			ID:               "cluster.restart-workload",
+			Label:            "Restart workload",
+			Description:      "Future guided action for an approved workload, routed through Kubernetes with audit logging.",
+			Risk:             "medium",
+			Enabled:          false,
+			RequiresApproval: true,
+			AuditEvent:       "cluster.guided_action.restart_workload",
+		},
 	}
 }
 
@@ -201,8 +441,18 @@ func getJSON[T any](ctx context.Context, client *http.Client, requestURL string,
 	return payload, resp.StatusCode, nil
 }
 
-func readClusterCA() (*x509.CertPool, error) {
-	caBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+func tokenBytes(cfg Config) ([]byte, error) {
+	if cfg.Token != "" {
+		return []byte(cfg.Token), nil
+	}
+	return os.ReadFile(cfg.TokenPath)
+}
+
+func readClusterCA(cfg Config) (*x509.CertPool, error) {
+	if cfg.CAPath == "" {
+		return nil, nil
+	}
+	caBytes, err := os.ReadFile(cfg.CAPath)
 	if err != nil {
 		return nil, err
 	}
@@ -213,4 +463,140 @@ func readClusterCA() (*x509.CertPool, error) {
 	}
 
 	return pool, nil
+}
+
+func podPhaseCounts(payload podListPayload) (running int, unhealthy int) {
+	for _, pod := range payload.Items {
+		if pod.Status.Phase == "Running" || pod.Status.Phase == "Succeeded" {
+			running++
+		} else {
+			unhealthy++
+		}
+	}
+	return running, unhealthy
+}
+
+func deploymentCounts(payload deploymentListPayload) (available int, desired int) {
+	for _, deployment := range payload.Items {
+		available += deployment.Status.AvailableReplicas
+		desired += deployment.Status.Replicas
+	}
+	return available, desired
+}
+
+func operatorIssueCount(payload clusterOperatorListPayload) int {
+	issues := 0
+	for _, operator := range payload.Items {
+		if conditionStatus(operator.Status.Conditions, "Available") != "True" ||
+			conditionStatus(operator.Status.Conditions, "Progressing") == "True" ||
+			conditionStatus(operator.Status.Conditions, "Degraded") == "True" {
+			issues++
+		}
+	}
+	return issues
+}
+
+func applicationIssueCount(payload argoApplicationListPayload) int {
+	issues := 0
+	for _, app := range payload.Items {
+		if app.Status.Health.Status != "Healthy" || app.Status.Sync.Status != "Synced" {
+			issues++
+		}
+	}
+	return issues
+}
+
+func conditionStatus(conditions []struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}, conditionType string) string {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status
+		}
+	}
+	return ""
+}
+
+func degradedReasons(nodes nodeListPayload, readyNodes int, unhealthyPods int, availableDeployments int, desiredDeployments int, deploymentsErr error, operatorIssues int, appsErr error, appIssues int, nodesErr error, podsErr error, operatorsErr error) []string {
+	reasons := make([]string, 0)
+	if nodesErr != nil {
+		reasons = append(reasons, "Node health could not be read.")
+	} else if readyNodes < len(nodes.Items) {
+		reasons = append(reasons, fmt.Sprintf("%d node(s) are not Ready.", len(nodes.Items)-readyNodes))
+	}
+	if podsErr != nil {
+		reasons = append(reasons, "Pod health could not be read.")
+	} else if unhealthyPods > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d pod(s) are not Running or Succeeded.", unhealthyPods))
+	}
+	if deploymentsErr != nil {
+		reasons = append(reasons, "Deployment health could not be read.")
+	} else if availableDeployments < desiredDeployments {
+		reasons = append(reasons, fmt.Sprintf("%d deployment replica(s) are unavailable.", desiredDeployments-availableDeployments))
+	}
+	if operatorsErr != nil {
+		reasons = append(reasons, "OpenShift operator health could not be read.")
+	} else if operatorIssues > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d OpenShift operator(s) need attention.", operatorIssues))
+	}
+	if appsErr != nil {
+		reasons = append(reasons, "Argo CD application status could not be read.")
+	} else if appIssues > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d Argo CD application(s) are not healthy and synced.", appIssues))
+	}
+	return reasons
+}
+
+func recommendedActions(reasons []string) []string {
+	if len(reasons) == 0 {
+		return []string{"No operator action is needed right now."}
+	}
+	return []string{"Open OpenShift or Argo CD for the affected resource before making changes."}
+}
+
+func highlights(version string, readyNodes int, nodeCount int, apps argoApplicationListPayload, appsErr error) []string {
+	items := []string{
+		fmt.Sprintf("OpenShift %s is reachable.", version),
+		fmt.Sprintf("%d of %d node(s) are Ready.", readyNodes, nodeCount),
+	}
+	if appsErr == nil {
+		items = append(items, fmt.Sprintf("%d Argo CD application(s) are visible to Asterism.", len(apps.Items)))
+	}
+	return items
+}
+
+func authoritativeLinks(cfg Config) []Link {
+	links := make([]Link, 0, 2)
+	if cfg.ConsoleURL != "" {
+		links = append(links, Link{Label: "Open OpenShift Console", Href: cfg.ConsoleURL})
+	}
+	if cfg.ArgoCDURL != "" {
+		links = append(links, Link{Label: "Open Argo CD", Href: cfg.ArgoCDURL})
+	}
+	return links
+}
+
+func stateForZero(value int) string {
+	if value == 0 {
+		return "ok"
+	}
+	return "warning"
+}
+
+func stateForEquality(left int, right int) string {
+	if left == right {
+		return "ok"
+	}
+	return "warning"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/services/cluster/internal/integration/probe_test.go
+++ b/services/cluster/internal/integration/probe_test.go
@@ -1,0 +1,71 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbeWithConfigSummarizesClusterAndGitOps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			http.Error(w, "missing token", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/version":
+			_, _ = fmt.Fprint(w, `{"gitVersion":"v1.34.6"}`)
+		case "/api/v1/nodes":
+			_, _ = fmt.Fprint(w, `{"items":[{"metadata":{"name":"node-a"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}`)
+		case "/api/v1/pods":
+			_, _ = fmt.Fprint(w, `{"items":[{"status":{"phase":"Running"}},{"status":{"phase":"Failed"}}]}`)
+		case "/api/v1/namespaces":
+			_, _ = fmt.Fprint(w, `{"items":[{},{}]}`)
+		case "/apis/apps/v1/deployments":
+			_, _ = fmt.Fprint(w, `{"items":[{"status":{"replicas":2,"availableReplicas":1}}]}`)
+		case "/apis/config.openshift.io/v1/clusterversions":
+			_, _ = fmt.Fprint(w, `{"items":[{"status":{"desired":{"version":"4.21.11"}}}]}`)
+		case "/apis/config.openshift.io/v1/clusteroperators":
+			_, _ = fmt.Fprint(w, `{"items":[{"metadata":{"name":"ingress"},"status":{"conditions":[{"type":"Available","status":"True"},{"type":"Progressing","status":"False"},{"type":"Degraded","status":"False"}]}}]}`)
+		case "/apis/argoproj.io/v1alpha1/namespaces/openshift-gitops/applications":
+			_, _ = fmt.Fprint(w, `{"items":[{"metadata":{"name":"app-asterism"},"status":{"health":{"status":"Healthy"},"sync":{"status":"Synced"}}}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	snapshot := ProbeWithConfig(context.Background(), Config{
+		Endpoint: server.URL + "/version",
+		Token:    "test-token",
+	})
+
+	if !snapshot.Configured || !snapshot.Reachable {
+		t.Fatalf("expected reachable configured snapshot, got %#v", snapshot)
+	}
+	if snapshot.Severity != "warning" {
+		t.Fatalf("expected warning severity for failed pod, got %q", snapshot.Severity)
+	}
+
+	metrics := snapshot.Metrics.(map[string]any)
+	if metrics["clusterVersion"] != "4.21.11" {
+		t.Fatalf("expected OpenShift version metric, got %#v", metrics["clusterVersion"])
+	}
+	if metrics["unhealthyPodCount"] != 1 {
+		t.Fatalf("expected one unhealthy pod, got %#v", metrics["unhealthyPodCount"])
+	}
+}
+
+func TestProbeWithConfigReportsUnconfiguredCluster(t *testing.T) {
+	snapshot := ProbeWithConfig(context.Background(), Config{})
+
+	if snapshot.Configured {
+		t.Fatalf("expected unconfigured snapshot")
+	}
+	if snapshot.Severity != "unknown" {
+		t.Fatalf("expected unknown severity, got %q", snapshot.Severity)
+	}
+}

--- a/services/cluster/ui/dashboard-card.js
+++ b/services/cluster/ui/dashboard-card.js
@@ -4,7 +4,7 @@ export function createDashboardCard({ title, description, statusApi }) {
     description,
     links: [
       {
-        label: "View status API",
+        label: "Status API",
         href: statusApi,
       },
     ],

--- a/services/cluster/ui/module.json
+++ b/services/cluster/ui/module.json
@@ -5,9 +5,10 @@
   "apiBasePath": "/api/services/cluster",
   "uiBasePath": "/ui/services/cluster",
   "dashboardCard": {
-    "title": "Cluster Status",
-    "description": "Runtime-loaded card owned by the cluster service.",
+    "title": "OpenShift Cluster",
+    "description": "Node, workload, operator, and GitOps status from read-only cluster APIs.",
     "statusEndpoint": "/api/v1/status",
+    "actionsEndpoint": "/api/v1/actions",
     "module": "/dashboard-card.js",
     "export": "createDashboardCard"
   }

--- a/services/pfsense/api/openapi.yaml
+++ b/services/pfsense/api/openapi.yaml
@@ -10,6 +10,72 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  schemas:
+    GuidedAction:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        description:
+          type: string
+        risk:
+          type: string
+        enabled:
+          type: boolean
+        requiresApproval:
+          type: boolean
+        auditEvent:
+          type: string
+    IntegrationSnapshot:
+      type: object
+      properties:
+        configured:
+          type: boolean
+        reachable:
+          type: boolean
+        endpoint:
+          type: string
+        message:
+          type: string
+        httpStatus:
+          type: integer
+        latencyMs:
+          type: integer
+        observedAt:
+          type: string
+          format: date-time
+        severity:
+          type: string
+          enum: [ok, warning, critical, unknown]
+        degradedReasons:
+          type: array
+          items:
+            type: string
+        recommendedActions:
+          type: array
+          items:
+            type: string
+        authoritativeLinks:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              href:
+                type: string
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GuidedAction'
+        metrics:
+          type: object
+          additionalProperties: true
+        summary:
+          type: object
+          additionalProperties: true
 paths:
   /healthz:
     get:
@@ -37,23 +103,64 @@ paths:
                   principal:
                     type: string
                   integration:
-                    type: object
-                    properties:
-                      configured:
-                        type: boolean
-                      reachable:
-                        type: boolean
-                      endpoint:
-                        type: string
-                      message:
-                        type: string
-                      httpStatus:
-                        type: integer
-                      latencyMs:
-                        type: integer
-                      metrics:
-                        type: object
-                        additionalProperties: true
+                    $ref: '#/components/schemas/IntegrationSnapshot'
+                  timestamp:
+                    type: string
+                    format: date-time
+        '401':
+          description: Missing identity context
+        '403':
+          description: Authenticated but not authorized
+  /api/v1/summary:
+    get:
+      summary: Return read-only pfSense operator summary
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current operator summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  status:
+                    type: string
+                  principal:
+                    type: string
+                  integration:
+                    $ref: '#/components/schemas/IntegrationSnapshot'
+                  timestamp:
+                    type: string
+                    format: date-time
+        '401':
+          description: Missing identity context
+        '403':
+          description: Authenticated but not authorized
+  /api/v1/actions:
+    get:
+      summary: Return available guided action contracts
+      description: Actions are advertised for UX and automation planning only; this endpoint does not mutate pfSense.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Guided action catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  principal:
+                    type: string
+                  actions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/GuidedAction'
                   timestamp:
                     type: string
                     format: date-time

--- a/services/pfsense/deploy/base/deployment.yaml
+++ b/services/pfsense/deploy/base/deployment.yaml
@@ -29,8 +29,36 @@ spec:
               value: "enforced"
             - name: AUTH_REQUIRED_GROUP
               value: ""
-            - name: PFSENSE_API_URL
-              value: ""
+            - name: PFSENSE_SNMP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: pfsense-secrets
+                  key: snmpHost
+                  optional: true
+            - name: PFSENSE_SNMP_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: pfsense-secrets
+                  key: snmpPort
+                  optional: true
+            - name: PFSENSE_SNMP_COMMUNITY
+              valueFrom:
+                secretKeyRef:
+                  name: pfsense-secrets
+                  key: snmpCommunity
+                  optional: true
+            - name: PFSENSE_CONSOLE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: pfsense-secrets
+                  key: consoleUrl
+                  optional: true
+            - name: PFSENSE_EXPECTED_UP_INTERFACES
+              valueFrom:
+                secretKeyRef:
+                  name: pfsense-secrets
+                  key: expectedUpInterfaces
+                  optional: true
           livenessProbe:
             httpGet:
               path: /healthz

--- a/services/pfsense/deploy/base/externalsecret.yaml
+++ b/services/pfsense/deploy/base/externalsecret.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pfsense-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secretsmanager
+  target:
+    name: pfsense-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: snmpHost
+      remoteRef:
+        key: /asterism/pfsense
+        property: snmpHost
+    - secretKey: snmpPort
+      remoteRef:
+        key: /asterism/pfsense
+        property: snmpPort
+    - secretKey: snmpCommunity
+      remoteRef:
+        key: /asterism/pfsense
+        property: snmpCommunity
+    - secretKey: consoleUrl
+      remoteRef:
+        key: /asterism/pfsense
+        property: consoleUrl
+    - secretKey: expectedUpInterfaces
+      remoteRef:
+        key: /asterism/pfsense
+        property: expectedUpInterfaces

--- a/services/pfsense/deploy/kustomization.yaml
+++ b/services/pfsense/deploy/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: asterism
 resources:
   - ./base/deployment.yaml
   - ./base/service.yaml
+  - ./base/externalsecret.yaml
 images:
   - name: pfsense
     newName: ghcr.io/jlfowle/asterism-pfsense

--- a/services/pfsense/go.mod
+++ b/services/pfsense/go.mod
@@ -1,3 +1,5 @@
 module github.com/jlfowle/asterism/services/pfsense
 
-go 1.23
+go 1.24.0
+
+require github.com/gosnmp/gosnmp v1.43.2

--- a/services/pfsense/go.sum
+++ b/services/pfsense/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gosnmp/gosnmp v1.43.2 h1:F9loz6uMCNtIQj0RNO5wz/mZ+FZt2WyNKJYOvw+Zosw=
+github.com/gosnmp/gosnmp v1.43.2/go.mod h1:smHIwoaqr1M+HTAEd7+mKkPs8lp3Lf/U+htPUql1Q3c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/services/pfsense/internal/api/handlers.go
+++ b/services/pfsense/internal/api/handlers.go
@@ -33,6 +33,8 @@ func (h Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(http.FS(uiassets.Files))))
 	mux.HandleFunc("/healthz", h.healthz)
 	mux.Handle("/api/v1/status", h.auth.Protect(http.HandlerFunc(h.status)))
+	mux.Handle("/api/v1/summary", h.auth.Protect(http.HandlerFunc(h.status)))
+	mux.Handle("/api/v1/actions", h.auth.Protect(http.HandlerFunc(h.actions)))
 }
 
 func (h Handler) healthz(w http.ResponseWriter, _ *http.Request) {
@@ -48,6 +50,24 @@ func (h Handler) status(w http.ResponseWriter, r *http.Request) {
 		Principal:   principalFromContext(r.Context()),
 		Integration: integration.Probe(r.Context()),
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h Handler) actions(w http.ResponseWriter, r *http.Request) {
+	resp := struct {
+		Service   string                `json:"service"`
+		Principal string                `json:"principal,omitempty"`
+		Actions   []integration.Control `json:"actions"`
+		Timestamp string                `json:"timestamp"`
+	}{
+		Service:   h.serviceName,
+		Principal: principalFromContext(r.Context()),
+		Actions:   integration.Actions(),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/services/pfsense/internal/api/handlers_test.go
+++ b/services/pfsense/internal/api/handlers_test.go
@@ -13,6 +13,14 @@ type statusTestResponse struct {
 	Principal string `json:"principal"`
 }
 
+type actionsTestResponse struct {
+	Service string `json:"service"`
+	Actions []struct {
+		ID      string `json:"id"`
+		Enabled bool   `json:"enabled"`
+	} `json:"actions"`
+}
+
 func TestHealthz(t *testing.T) {
 	h := NewHandler("pfsense")
 	mux := http.NewServeMux()
@@ -77,7 +85,8 @@ func TestStatusUnauthorizedWhenMissingPrincipal(t *testing.T) {
 func TestStatusAuthorizedWithPrincipal(t *testing.T) {
 	t.Setenv("AUTH_MODE", "enforced")
 	t.Setenv("AUTH_REQUIRED_GROUP", "")
-	t.Setenv("PFSENSE_API_URL", "")
+	t.Setenv("PFSENSE_SNMP_HOST", "")
+	t.Setenv("PFSENSE_SNMP_COMMUNITY", "")
 
 	h := NewHandler("pfsense")
 	mux := http.NewServeMux()
@@ -104,5 +113,39 @@ func TestStatusAuthorizedWithPrincipal(t *testing.T) {
 
 	if payload.Principal != "test-user" {
 		t.Fatalf("expected principal %q, got %q", "test-user", payload.Principal)
+	}
+}
+
+func TestActionsAuthorizedWithPrincipal(t *testing.T) {
+	t.Setenv("AUTH_MODE", "enforced")
+	t.Setenv("AUTH_REQUIRED_GROUP", "")
+
+	h := NewHandler("pfsense")
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil)
+	req.Header.Set("X-Asterism-Principal", "test-user")
+
+	res := httptest.NewRecorder()
+	mux.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+
+	var payload actionsTestResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to unmarshal actions response: %v", err)
+	}
+
+	if payload.Service != "pfsense" {
+		t.Fatalf("expected service %q, got %q", "pfsense", payload.Service)
+	}
+	if len(payload.Actions) == 0 {
+		t.Fatalf("expected guided action contracts")
+	}
+	if payload.Actions[0].Enabled {
+		t.Fatalf("expected guided actions to be disabled in observe-first milestone")
 	}
 }

--- a/services/pfsense/internal/integration/probe.go
+++ b/services/pfsense/internal/integration/probe.go
@@ -2,105 +2,491 @@ package integration
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gosnmp/gosnmp"
 )
 
 type Snapshot struct {
-	Configured bool   `json:"configured"`
-	Reachable  bool   `json:"reachable"`
-	Endpoint   string `json:"endpoint,omitempty"`
-	Message    string `json:"message"`
-	HTTPStatus int    `json:"httpStatus,omitempty"`
-	LatencyMs  int64  `json:"latencyMs,omitempty"`
-	Metrics    any    `json:"metrics,omitempty"`
+	Configured         bool      `json:"configured"`
+	Reachable          bool      `json:"reachable"`
+	Endpoint           string    `json:"endpoint,omitempty"`
+	Message            string    `json:"message"`
+	HTTPStatus         int       `json:"httpStatus,omitempty"`
+	LatencyMs          int64     `json:"latencyMs,omitempty"`
+	ObservedAt         string    `json:"observedAt"`
+	Severity           string    `json:"severity"`
+	DegradedReasons    []string  `json:"degradedReasons,omitempty"`
+	RecommendedActions []string  `json:"recommendedActions,omitempty"`
+	AuthoritativeLinks []Link    `json:"authoritativeLinks,omitempty"`
+	Controls           []Control `json:"controls,omitempty"`
+	Metrics            any       `json:"metrics,omitempty"`
+	Summary            Summary   `json:"summary,omitempty"`
+}
+
+type Summary struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Stats       []Stat   `json:"stats,omitempty"`
+	Highlights  []string `json:"highlights,omitempty"`
+}
+
+type Stat struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+	Unit  string `json:"unit,omitempty"`
+	State string `json:"state,omitempty"`
+}
+
+type Link struct {
+	Label string `json:"label"`
+	Href  string `json:"href"`
+}
+
+type Control struct {
+	ID               string `json:"id"`
+	Label            string `json:"label"`
+	Description      string `json:"description"`
+	Risk             string `json:"risk"`
+	Enabled          bool   `json:"enabled"`
+	RequiresApproval bool   `json:"requiresApproval"`
+	AuditEvent       string `json:"auditEvent"`
+}
+
+type Config struct {
+	Host                 string
+	Port                 uint16
+	Community            string
+	ConsoleURL           string
+	ExpectedUpInterfaces []string
+	Timeout              time.Duration
+}
+
+type SNMPClient interface {
+	Get(oids []string) (*gosnmp.SnmpPacket, error)
+	WalkAll(rootOid string) ([]gosnmp.SnmpPDU, error)
 }
 
 func Probe(ctx context.Context) Snapshot {
-	endpoint := os.Getenv("PFSENSE_API_URL")
-	token := os.Getenv("PFSENSE_API_TOKEN")
+	return ProbeWithClient(ctx, newSNMPClient, ConfigFromEnv())
+}
 
-	if endpoint == "" {
-		return Snapshot{
-			Configured: false,
-			Reachable:  false,
-			Message:    "integration not configured",
+func ConfigFromEnv() Config {
+	port := uint16(161)
+	if rawPort := strings.TrimSpace(os.Getenv("PFSENSE_SNMP_PORT")); rawPort != "" {
+		if parsed, err := strconv.ParseUint(rawPort, 10, 16); err == nil {
+			port = uint16(parsed)
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeout := 5 * time.Second
+	if rawTimeout := strings.TrimSpace(os.Getenv("PFSENSE_SNMP_TIMEOUT")); rawTimeout != "" {
+		if parsed, err := time.ParseDuration(rawTimeout); err == nil {
+			timeout = parsed
+		}
+	}
+
+	return Config{
+		Host:                 strings.TrimSpace(os.Getenv("PFSENSE_SNMP_HOST")),
+		Port:                 port,
+		Community:            strings.TrimSpace(os.Getenv("PFSENSE_SNMP_COMMUNITY")),
+		ConsoleURL:           strings.TrimSpace(os.Getenv("PFSENSE_CONSOLE_URL")),
+		ExpectedUpInterfaces: splitCSV(os.Getenv("PFSENSE_EXPECTED_UP_INTERFACES")),
+		Timeout:              timeout,
+	}
+}
+
+func ProbeWithClient(ctx context.Context, clientFactory func(Config) (SNMPClient, func() error, error), cfg Config) Snapshot {
+	observedAt := time.Now().UTC().Format(time.RFC3339)
+
+	if cfg.Host == "" || cfg.Community == "" {
+		return Snapshot{
+			Configured:         false,
+			Reachable:          false,
+			Message:            "pfSense read-only monitoring is not configured yet.",
+			ObservedAt:         observedAt,
+			Severity:           "unknown",
+			RecommendedActions: []string{"Enable pfSense SNMP with a non-default read community and restrict access to Asterism."},
+			Controls:           Actions(),
+			Summary: Summary{
+				Title:       "pfSense needs SNMP details",
+				Description: "Asterism can show firewall and gateway health after read-only SNMP is configured.",
+			},
+		}
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("failed to create request: %v", err),
-		}
-	}
-
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-
 	startedAt := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	client, closeClient, err := clientFactory(cfg)
 	if err != nil {
 		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("request failed: %v", err),
+			Configured:         true,
+			Reachable:          false,
+			Endpoint:           endpoint(cfg),
+			Message:            fmt.Sprintf("pfSense SNMP connection failed: %v", err),
+			LatencyMs:          time.Since(startedAt).Milliseconds(),
+			ObservedAt:         observedAt,
+			Severity:           "critical",
+			DegradedReasons:    []string{"Asterism could not connect to pfSense SNMP."},
+			RecommendedActions: []string{"Confirm pfSense SNMP host, community, firewall rules, and interface binding."},
+			AuthoritativeLinks: authoritativeLinks(cfg),
+			Controls:           Actions(),
+			Summary: Summary{
+				Title:       "pfSense is unreachable",
+				Description: "Gateway status is unavailable until SNMP responds.",
+			},
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = closeClient() }()
 
+	type result struct {
+		system     *gosnmp.SnmpPacket
+		interfaces []interfaceState
+		err        error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		systemPacket, err := client.Get([]string{
+			".1.3.6.1.2.1.1.1.0",
+			".1.3.6.1.2.1.1.3.0",
+			".1.3.6.1.2.1.1.5.0",
+		})
+		if err != nil {
+			resultCh <- result{err: err}
+			return
+		}
+		interfaces, err := readInterfaces(client)
+		resultCh <- result{system: systemPacket, interfaces: interfaces, err: err}
+	}()
+
+	var probeResult result
+	select {
+	case <-ctx.Done():
+		probeResult.err = ctx.Err()
+	case probeResult = <-resultCh:
+	}
 	latencyMs := time.Since(startedAt).Milliseconds()
-	metrics := map[string]any{
-		"statusClass": fmt.Sprintf("%dxx", resp.StatusCode/100),
-	}
 
-	contentType := resp.Header.Get("Content-Type")
-	if strings.Contains(contentType, "application/json") {
-		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		if readErr == nil {
-			var payload map[string]any
-			if unmarshalErr := json.Unmarshal(bodyBytes, &payload); unmarshalErr == nil {
-				for _, key := range []string{"name", "version", "status", "uptime"} {
-					if value, exists := payload[key]; exists {
-						metrics[key] = value
-					}
-				}
-			}
-		}
-	}
-
-	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+	if probeResult.err != nil {
 		return Snapshot{
-			Configured: true,
-			Reachable:  true,
-			Endpoint:   endpoint,
-			Message:    "upstream API reachable",
-			HTTPStatus: resp.StatusCode,
-			LatencyMs:  latencyMs,
-			Metrics:    metrics,
+			Configured:         true,
+			Reachable:          false,
+			Endpoint:           endpoint(cfg),
+			Message:            fmt.Sprintf("pfSense SNMP request failed: %v", probeResult.err),
+			LatencyMs:          latencyMs,
+			ObservedAt:         observedAt,
+			Severity:           "critical",
+			DegradedReasons:    []string{"Asterism could not read pfSense SNMP status."},
+			RecommendedActions: []string{"Check SNMP service, read community, and pfSense firewall rules."},
+			AuthoritativeLinks: authoritativeLinks(cfg),
+			Controls:           Actions(),
+			Summary: Summary{
+				Title:       "pfSense SNMP is not responding",
+				Description: "Firewall status is unavailable until the read-only SNMP endpoint responds.",
+			},
 		}
+	}
+
+	system := parseSystem(probeResult.system)
+	interfaceSummary := summarizeInterfaces(probeResult.interfaces, cfg.ExpectedUpInterfaces)
+	reasons := interfaceSummary.Reasons
+	severity := "ok"
+	message := "pfSense SNMP is reachable."
+	if len(reasons) > 0 {
+		severity = "warning"
+		message = "pfSense SNMP is reachable with gateway items to review."
+	}
+
+	metrics := map[string]any{
+		"systemName":                system.Name,
+		"systemDescription":         system.Description,
+		"uptimeSeconds":             system.UptimeSeconds,
+		"interfaceCount":            len(probeResult.interfaces),
+		"upInterfaceCount":          interfaceSummary.Up,
+		"downInterfaceCount":        interfaceSummary.Down,
+		"expectedInterfaceCount":    len(cfg.ExpectedUpInterfaces),
+		"expectedInterfacesHealthy": len(interfaceSummary.Reasons) == 0,
 	}
 
 	return Snapshot{
-		Configured: true,
-		Reachable:  false,
-		Endpoint:   endpoint,
-		Message:    fmt.Sprintf("upstream returned status %d", resp.StatusCode),
-		HTTPStatus: resp.StatusCode,
-		LatencyMs:  latencyMs,
-		Metrics:    metrics,
+		Configured:         true,
+		Reachable:          true,
+		Endpoint:           endpoint(cfg),
+		Message:            message,
+		LatencyMs:          latencyMs,
+		ObservedAt:         observedAt,
+		Severity:           severity,
+		DegradedReasons:    reasons,
+		RecommendedActions: recommendedActions(reasons),
+		AuthoritativeLinks: authoritativeLinks(cfg),
+		Controls:           Actions(),
+		Metrics:            metrics,
+		Summary: Summary{
+			Title:       "pfSense gateway overview",
+			Description: "Read-only status from pfSense SNMP.",
+			Stats: []Stat{
+				{Label: "SNMP", Value: "reachable", State: "ok"},
+				{Label: "Interfaces up", Value: fmt.Sprintf("%d/%d", interfaceSummary.Up, len(probeResult.interfaces)), State: stateForReasons(reasons)},
+				{Label: "Expected links", Value: fmt.Sprintf("%d", len(cfg.ExpectedUpInterfaces)), State: stateForReasons(reasons)},
+				{Label: "Uptime", Value: formatDuration(system.UptimeSeconds), State: "ok"},
+			},
+			Highlights: highlights(system, interfaceSummary, cfg.ExpectedUpInterfaces),
+		},
 	}
+}
+
+func Actions() []Control {
+	return []Control{
+		{
+			ID:               "pfsense.renew-wan",
+			Label:            "Renew WAN lease",
+			Description:      "Future guided action that would ask pfSense to renew a selected WAN DHCP lease through a backend-owned API.",
+			Risk:             "medium",
+			Enabled:          false,
+			RequiresApproval: true,
+			AuditEvent:       "pfsense.guided_action.renew_wan",
+		},
+		{
+			ID:               "pfsense.open-firewall-log",
+			Label:            "Open firewall log",
+			Description:      "Future guided action that deep-links a non-expert to the relevant pfSense firewall log view.",
+			Risk:             "low",
+			Enabled:          false,
+			RequiresApproval: false,
+			AuditEvent:       "pfsense.guided_action.open_firewall_log",
+		},
+	}
+}
+
+func newSNMPClient(cfg Config) (SNMPClient, func() error, error) {
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	client := &gosnmp.GoSNMP{
+		Target:    cfg.Host,
+		Port:      cfg.Port,
+		Community: cfg.Community,
+		Version:   gosnmp.Version2c,
+		Timeout:   timeout,
+		Retries:   1,
+	}
+	if err := client.Connect(); err != nil {
+		return nil, func() error { return nil }, err
+	}
+	return client, client.Conn.Close, nil
+}
+
+type interfaceState struct {
+	Index int
+	Name  string
+	Up    bool
+}
+
+func readInterfaces(client SNMPClient) ([]interfaceState, error) {
+	names, err := client.WalkAll(".1.3.6.1.2.1.2.2.1.2")
+	if err != nil {
+		return nil, err
+	}
+	states, err := client.WalkAll(".1.3.6.1.2.1.2.2.1.8")
+	if err != nil {
+		return nil, err
+	}
+
+	byIndex := make(map[int]*interfaceState)
+	for _, pdu := range names {
+		index := oidIndex(pdu.Name)
+		state := byIndex[index]
+		if state == nil {
+			state = &interfaceState{Index: index}
+			byIndex[index] = state
+		}
+		state.Name = pduString(pdu)
+	}
+	for _, pdu := range states {
+		index := oidIndex(pdu.Name)
+		state := byIndex[index]
+		if state == nil {
+			state = &interfaceState{Index: index}
+			byIndex[index] = state
+		}
+		state.Up = pduInt(pdu) == 1
+	}
+
+	interfaces := make([]interfaceState, 0, len(byIndex))
+	for _, state := range byIndex {
+		interfaces = append(interfaces, *state)
+	}
+	return interfaces, nil
+}
+
+type systemInfo struct {
+	Description   string
+	Name          string
+	UptimeSeconds int64
+}
+
+func parseSystem(packet *gosnmp.SnmpPacket) systemInfo {
+	var info systemInfo
+	if packet == nil {
+		return info
+	}
+	for _, variable := range packet.Variables {
+		switch variable.Name {
+		case ".1.3.6.1.2.1.1.1.0":
+			info.Description = pduString(variable)
+		case ".1.3.6.1.2.1.1.3.0":
+			info.UptimeSeconds = int64(pduInt(variable)) / 100
+		case ".1.3.6.1.2.1.1.5.0":
+			info.Name = pduString(variable)
+		}
+	}
+	return info
+}
+
+type interfaceSummary struct {
+	Up      int
+	Down    int
+	Reasons []string
+}
+
+func summarizeInterfaces(interfaces []interfaceState, expected []string) interfaceSummary {
+	summary := interfaceSummary{}
+	byName := make(map[string]interfaceState, len(interfaces))
+	for _, item := range interfaces {
+		if item.Up {
+			summary.Up++
+		} else {
+			summary.Down++
+		}
+		byName[strings.ToLower(item.Name)] = item
+	}
+
+	for _, expectedName := range expected {
+		item, exists := byName[strings.ToLower(expectedName)]
+		if !exists {
+			summary.Reasons = append(summary.Reasons, fmt.Sprintf("Expected pfSense interface %q was not reported by SNMP.", expectedName))
+			continue
+		}
+		if !item.Up {
+			summary.Reasons = append(summary.Reasons, fmt.Sprintf("Expected pfSense interface %q is down.", expectedName))
+		}
+	}
+	return summary
+}
+
+func recommendedActions(reasons []string) []string {
+	if len(reasons) == 0 {
+		return []string{"No operator action is needed right now."}
+	}
+	return []string{"Open pfSense to inspect the affected gateway or interface before making changes."}
+}
+
+func highlights(system systemInfo, summary interfaceSummary, expected []string) []string {
+	name := system.Name
+	if name == "" {
+		name = "pfSense"
+	}
+	items := []string{
+		fmt.Sprintf("%s is reachable by read-only SNMP.", name),
+		fmt.Sprintf("%d interfaces are up and %d are down.", summary.Up, summary.Down),
+	}
+	if len(expected) == 0 {
+		items = append(items, "No expected-up interface list is configured, so down interfaces are informational.")
+	}
+	return items
+}
+
+func authoritativeLinks(cfg Config) []Link {
+	if cfg.ConsoleURL == "" {
+		return nil
+	}
+	return []Link{{Label: "Open pfSense", Href: cfg.ConsoleURL}}
+}
+
+func endpoint(cfg Config) string {
+	return fmt.Sprintf("snmp://%s:%d", cfg.Host, cfg.Port)
+}
+
+func splitCSV(raw string) []string {
+	parts := strings.Split(raw, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return values
+}
+
+func oidIndex(oid string) int {
+	parts := strings.Split(strings.Trim(oid, "."), ".")
+	if len(parts) == 0 {
+		return 0
+	}
+	parsed, _ := strconv.Atoi(parts[len(parts)-1])
+	return parsed
+}
+
+func pduString(pdu gosnmp.SnmpPDU) string {
+	switch value := pdu.Value.(type) {
+	case string:
+		return value
+	case []byte:
+		return string(value)
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+func pduInt(pdu gosnmp.SnmpPDU) int {
+	switch value := pdu.Value.(type) {
+	case int:
+		return value
+	case uint:
+		return int(value)
+	case uint32:
+		return int(value)
+	case uint64:
+		return int(value)
+	case int64:
+		return int(value)
+	default:
+		parsed, _ := strconv.Atoi(fmt.Sprintf("%v", value))
+		return parsed
+	}
+}
+
+func formatDuration(seconds int64) string {
+	if seconds <= 0 {
+		return "unknown"
+	}
+	duration := time.Duration(seconds) * time.Second
+	days := int(duration.Hours()) / 24
+	if days > 0 {
+		return fmt.Sprintf("%dd", days)
+	}
+	hours := int(duration.Hours())
+	if hours > 0 {
+		return fmt.Sprintf("%dh", hours)
+	}
+	return fmt.Sprintf("%dm", int(duration.Minutes()))
+}
+
+func stateForReasons(reasons []string) string {
+	if len(reasons) == 0 {
+		return "ok"
+	}
+	return "warning"
 }

--- a/services/pfsense/internal/integration/probe_test.go
+++ b/services/pfsense/internal/integration/probe_test.go
@@ -1,0 +1,78 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+type fakeSNMPClient struct{}
+
+func (f fakeSNMPClient) Get(_ []string) (*gosnmp.SnmpPacket, error) {
+	return &gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{Name: ".1.3.6.1.2.1.1.1.0", Value: "pfSense test firewall"},
+			{Name: ".1.3.6.1.2.1.1.3.0", Value: uint32(360000)},
+			{Name: ".1.3.6.1.2.1.1.5.0", Value: "edge-fw"},
+		},
+	}, nil
+}
+
+func (f fakeSNMPClient) WalkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
+	switch rootOid {
+	case ".1.3.6.1.2.1.2.2.1.2":
+		return []gosnmp.SnmpPDU{
+			{Name: ".1.3.6.1.2.1.2.2.1.2.1", Value: "wan"},
+			{Name: ".1.3.6.1.2.1.2.2.1.2.2", Value: "lan"},
+		}, nil
+	case ".1.3.6.1.2.1.2.2.1.8":
+		return []gosnmp.SnmpPDU{
+			{Name: ".1.3.6.1.2.1.2.2.1.8.1", Value: 1},
+			{Name: ".1.3.6.1.2.1.2.2.1.8.2", Value: 2},
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func TestProbeWithClientSummarizesPFSenseSNMP(t *testing.T) {
+	factory := func(Config) (SNMPClient, func() error, error) {
+		return fakeSNMPClient{}, func() error { return nil }, nil
+	}
+
+	snapshot := ProbeWithClient(context.Background(), factory, Config{
+		Host:                 "pfsense.local",
+		Port:                 161,
+		Community:            "readonly",
+		ExpectedUpInterfaces: []string{"wan", "lan"},
+		Timeout:              time.Second,
+	})
+
+	if !snapshot.Configured || !snapshot.Reachable {
+		t.Fatalf("expected reachable configured snapshot, got %#v", snapshot)
+	}
+	if snapshot.Severity != "warning" {
+		t.Fatalf("expected warning for down expected interface, got %q", snapshot.Severity)
+	}
+
+	metrics := snapshot.Metrics.(map[string]any)
+	if metrics["systemName"] != "edge-fw" {
+		t.Fatalf("expected system name edge-fw, got %#v", metrics["systemName"])
+	}
+	if metrics["downInterfaceCount"] != 1 {
+		t.Fatalf("expected one down interface, got %#v", metrics["downInterfaceCount"])
+	}
+}
+
+func TestProbeWithClientReportsUnconfiguredPFSense(t *testing.T) {
+	snapshot := ProbeWithClient(context.Background(), nil, Config{})
+
+	if snapshot.Configured {
+		t.Fatalf("expected unconfigured snapshot")
+	}
+	if snapshot.Severity != "unknown" {
+		t.Fatalf("expected unknown severity, got %q", snapshot.Severity)
+	}
+}

--- a/services/pfsense/ui/dashboard-card.js
+++ b/services/pfsense/ui/dashboard-card.js
@@ -4,7 +4,7 @@ export function createDashboardCard({ title, description, statusApi }) {
     description,
     links: [
       {
-        label: "View status API",
+        label: "Status API",
         href: statusApi,
       },
     ],

--- a/services/pfsense/ui/module.json
+++ b/services/pfsense/ui/module.json
@@ -5,9 +5,10 @@
   "apiBasePath": "/api/services/pfsense",
   "uiBasePath": "/ui/services/pfsense",
   "dashboardCard": {
-    "title": "pfSense Status",
-    "description": "Runtime-loaded card owned by the pfsense service.",
+    "title": "pfSense Gateway",
+    "description": "Firewall and gateway status from read-only pfSense SNMP.",
     "statusEndpoint": "/api/v1/status",
+    "actionsEndpoint": "/api/v1/actions",
     "module": "/dashboard-card.js",
     "export": "createDashboardCard"
   }

--- a/services/polaris/deploy/base/deployment.yaml
+++ b/services/polaris/deploy/base/deployment.yaml
@@ -22,6 +22,11 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          volumeMounts:
+            - name: oidc-config
+              mountPath: /usr/share/nginx/html/oidc-config.json
+              subPath: oidc-config.json
+              readOnly: true
           env:
             - name: PORT
               value: "8080"
@@ -46,3 +51,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+        - name: oidc-config
+          configMap:
+            name: polaris-oidc-config

--- a/services/polaris/deploy/base/oidc-configmap.yaml
+++ b/services/polaris/deploy/base/oidc-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: polaris-oidc-config
+data:
+  oidc-config.json: |
+    {
+      "enabled": false,
+      "issuer": "",
+      "clientId": "",
+      "authorizationEndpoint": "",
+      "tokenEndpoint": "",
+      "logoutEndpoint": "",
+      "scopes": ["openid", "profile", "email"]
+    }

--- a/services/polaris/deploy/kustomization.yaml
+++ b/services/polaris/deploy/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: asterism
 resources:
   - ./base/deployment.yaml
   - ./base/service.yaml
+  - ./base/oidc-configmap.yaml
 images:
   - name: polaris
     newName: ghcr.io/jlfowle/asterism-polaris

--- a/services/polaris/src/App.css
+++ b/services/polaris/src/App.css
@@ -1,15 +1,17 @@
 :root {
-  --bg-900: #06131f;
-  --bg-800: #0b1f31;
-  --bg-700: #14314a;
-  --ink-100: #e8f0f8;
-  --ink-300: #a7c0d8;
-  --panel-strong: rgba(8, 26, 41, 0.76);
-  --panel-soft: rgba(13, 39, 61, 0.58);
-  --line-soft: rgba(176, 211, 237, 0.24);
-  --accent: #35d0a1;
-  --warn: #f5bd4e;
-  --danger: #ef6f6c;
+  --page: #f4f6f8;
+  --surface: #ffffff;
+  --surface-muted: #edf1f4;
+  --ink: #17202a;
+  --ink-muted: #607080;
+  --line: #d7dee5;
+  --nav: #24313d;
+  --nav-ink: #eef4f7;
+  --ok: #21866f;
+  --warn: #a86500;
+  --danger: #bd3434;
+  --unknown: #697586;
+  --link: #1769aa;
 }
 
 * {
@@ -18,13 +20,17 @@
 
 body {
   margin: 0;
-  font-family: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
-  color: var(--ink-100);
-  background:
-    radial-gradient(circle at 15% 20%, rgba(53, 208, 161, 0.2), transparent 35%),
-    radial-gradient(circle at 90% 0%, rgba(95, 155, 242, 0.14), transparent 40%),
-    linear-gradient(145deg, var(--bg-900), var(--bg-700));
+  font-family: Inter, "Avenir Next", Arial, sans-serif;
+  color: var(--ink);
+  background: var(--page);
   min-height: 100vh;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
 }
 
 .dashboard-layout {
@@ -36,41 +42,67 @@ body {
 .topbar {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: center;
   gap: 1rem;
-  padding: 2rem clamp(1rem, 2vw, 2.5rem) 1.5rem;
-  border-bottom: 1px solid var(--line-soft);
-  backdrop-filter: blur(10px);
-  background: linear-gradient(180deg, rgba(7, 18, 28, 0.7), rgba(7, 18, 28, 0.25));
+  padding: 1.25rem clamp(1rem, 2vw, 2rem);
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
 }
 
 .eyebrow {
   margin: 0;
-  color: var(--accent);
+  color: var(--ok);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-weight: 600;
+  font-weight: 700;
   font-size: 0.72rem;
 }
 
 .topbar h1 {
-  margin: 0.25rem 0;
-  font-size: clamp(1.45rem, 2.4vw, 2.2rem);
-  letter-spacing: 0.02em;
+  margin: 0.2rem 0;
+  font-size: clamp(1.35rem, 2.2vw, 2rem);
 }
 
 .subtitle {
   margin: 0;
-  color: var(--ink-300);
+  color: var(--ink-muted);
+}
+
+.identity-panel {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .status-pill {
-  padding: 0.45rem 0.8rem;
-  border: 1px solid rgba(53, 208, 161, 0.5);
-  background: rgba(53, 208, 161, 0.12);
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--line);
+  background: var(--surface-muted);
   border-radius: 999px;
   font-size: 0.82rem;
   white-space: nowrap;
+}
+
+.identity-panel button,
+.control-row button {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--ink);
+  padding: 0.45rem 0.7rem;
+  cursor: pointer;
+}
+
+.identity-panel button:hover {
+  border-color: var(--link);
+  color: var(--link);
+}
+
+.control-row button:disabled {
+  cursor: not-allowed;
+  color: var(--unknown);
+  background: var(--surface-muted);
 }
 
 .dashboard-body {
@@ -81,17 +113,17 @@ body {
 }
 
 .sidebar {
-  border-right: 1px solid var(--line-soft);
+  border-right: 1px solid #1a2631;
   padding: 1.25rem 1rem;
-  background: linear-gradient(180deg, rgba(8, 27, 42, 0.78), rgba(8, 27, 42, 0.24));
+  background: var(--nav);
+  color: var(--nav-ink);
 }
 
 .sidebar-heading {
   margin: 0 0 0.75rem;
   font-size: 0.78rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--ink-300);
+  color: #bac7d3;
 }
 
 .sidebar ul {
@@ -101,28 +133,27 @@ body {
 }
 
 .sidebar li + li {
-  margin-top: 0.35rem;
+  margin-top: 0.3rem;
 }
 
 .sidebar a {
   display: block;
-  color: var(--ink-100);
+  color: var(--nav-ink);
   text-decoration: none;
   padding: 0.5rem 0.65rem;
-  border-radius: 0.45rem;
-  transition: background-color 180ms ease;
+  border-radius: 6px;
 }
 
 .sidebar a:hover {
-  background: rgba(119, 178, 229, 0.14);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .sidebar-footnote {
   margin-top: 1rem;
   padding: 0.75rem;
-  border: 1px solid var(--line-soft);
-  border-radius: 0.55rem;
-  color: var(--ink-300);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  color: #c5d1db;
   font-size: 0.78rem;
   line-height: 1.45;
 }
@@ -133,22 +164,21 @@ body {
 }
 
 .hero-panel {
-  border: 1px solid var(--line-soft);
-  background: var(--panel-strong);
-  border-radius: 0.9rem;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 8px;
   padding: 1rem 1.1rem;
   margin-bottom: 1rem;
-  animation: rise-in 500ms ease;
 }
 
 .hero-panel h2 {
   margin: 0;
-  font-size: 1.3rem;
+  font-size: 1.25rem;
 }
 
 .hero-panel p {
-  color: var(--ink-300);
-  max-width: 70ch;
+  color: var(--ink-muted);
+  max-width: 76ch;
 }
 
 .hero-stats {
@@ -160,9 +190,9 @@ body {
 .hero-stat {
   min-width: 155px;
   padding: 0.65rem 0.8rem;
-  border: 1px solid rgba(151, 205, 244, 0.25);
-  border-radius: 0.6rem;
-  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-muted);
 }
 
 .hero-stat strong {
@@ -171,22 +201,34 @@ body {
 }
 
 .hero-stat span {
-  color: var(--ink-300);
+  color: var(--ink-muted);
   font-size: 0.84rem;
 }
 
 .service-grid {
   display: grid;
   gap: 0.9rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .service-card {
-  border: 1px solid var(--line-soft);
-  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+  border-left: 5px solid var(--unknown);
+  border-radius: 8px;
   padding: 0.95rem;
-  background: linear-gradient(170deg, var(--panel-strong), var(--panel-soft));
-  animation: rise-in 600ms ease;
+  background: var(--surface);
+}
+
+.service-card-ok {
+  border-left-color: var(--ok);
+}
+
+.service-card-warning {
+  border-left-color: var(--warn);
+}
+
+.service-card-critical {
+  border-left-color: var(--danger);
 }
 
 .service-card-top {
@@ -198,61 +240,130 @@ body {
 
 .service-card h3 {
   margin: 0;
+  font-size: 1rem;
 }
 
 .service-card p {
-  color: var(--ink-300);
+  color: var(--ink-muted);
 }
 
 .service-state {
   font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
   padding: 0.2rem 0.5rem;
   border-radius: 999px;
   border: 1px solid;
+  white-space: nowrap;
 }
 
-.service-state-idle,
-.service-state-loading {
+.service-state-ok {
+  color: var(--ok);
+  border-color: rgba(33, 134, 111, 0.5);
+  background: rgba(33, 134, 111, 0.1);
+}
+
+.service-state-warning {
   color: var(--warn);
-  border-color: rgba(245, 189, 78, 0.6);
-  background: rgba(245, 189, 78, 0.13);
+  border-color: rgba(168, 101, 0, 0.45);
+  background: rgba(168, 101, 0, 0.1);
 }
 
-.service-state-ready {
-  color: var(--accent);
-  border-color: rgba(53, 208, 161, 0.55);
-  background: rgba(53, 208, 161, 0.13);
-}
-
-.service-state-error {
+.service-state-critical {
   color: var(--danger);
-  border-color: rgba(239, 111, 108, 0.55);
-  background: rgba(239, 111, 108, 0.13);
+  border-color: rgba(189, 52, 52, 0.45);
+  background: rgba(189, 52, 52, 0.1);
+}
+
+.service-state-unknown {
+  color: var(--unknown);
+  border-color: rgba(105, 117, 134, 0.45);
+  background: rgba(105, 117, 134, 0.1);
+}
+
+.service-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 0.85rem 0;
+}
+
+.service-stat {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.55rem;
+  min-height: 66px;
+  background: #fafbfc;
+}
+
+.service-stat span,
+.service-detail-row span {
+  display: block;
+  color: var(--ink-muted);
+  font-size: 0.78rem;
+}
+
+.service-stat strong {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 1rem;
+}
+
+.service-stat-ok strong {
+  color: var(--ok);
+}
+
+.service-stat-warning strong {
+  color: var(--warn);
 }
 
 .service-detail-row {
   display: flex;
   justify-content: space-between;
   gap: 0.7rem;
-  margin-top: 0.34rem;
+  margin-top: 0.4rem;
   font-size: 0.88rem;
-}
-
-.service-detail-row span {
-  color: var(--ink-300);
 }
 
 .service-message {
   margin-top: 0.65rem;
-  min-height: 2.25em;
+  min-height: 2em;
 }
 
-.service-card a {
-  display: inline-block;
-  margin-top: 0.35rem;
-  color: #80d5ff;
+.status-list,
+.review-panel ul {
+  margin: 0.4rem 0 0;
+  padding-left: 1.05rem;
+  color: var(--ink-muted);
+  font-size: 0.86rem;
+}
+
+.review-panel {
+  margin-top: 0.75rem;
+  border: 1px solid rgba(168, 101, 0, 0.28);
+  border-radius: 6px;
+  padding: 0.65rem;
+  background: rgba(168, 101, 0, 0.08);
+}
+
+.next-steps {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+  color: var(--ink-muted);
+  font-size: 0.86rem;
+}
+
+.control-row,
+.link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+}
+
+.link-row a {
+  color: var(--link);
+  font-size: 0.88rem;
 }
 
 @media (max-width: 900px) {
@@ -262,23 +373,15 @@ body {
 
   .sidebar {
     border-right: 0;
-    border-bottom: 1px solid var(--line-soft);
+    border-bottom: 1px solid #1a2631;
   }
 
   .topbar {
-    flex-direction: column;
     align-items: flex-start;
-  }
-}
-
-@keyframes rise-in {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
+    flex-direction: column;
   }
 
-  to {
-    opacity: 1;
-    transform: translateY(0);
+  .identity-panel {
+    justify-content: flex-start;
   }
 }

--- a/services/polaris/src/App.js
+++ b/services/polaris/src/App.js
@@ -1,17 +1,75 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Topbar from "./components/Topbar";
 import Sidebar from "./components/Sidebar";
 import MainContent from "./components/MainContent";
+import {
+  buildAuthState,
+  completeSignInIfNeeded,
+  disabledAuthState,
+  loadOidcConfig,
+  signOut,
+  startSignIn,
+} from "./auth";
 import "./App.css";
 
-const App = () => (
-  <div className="dashboard-layout">
-    <Topbar />
-    <div className="dashboard-body">
-      <Sidebar />
-      <MainContent />
+const loadingAuthState = {
+  ...disabledAuthState,
+  ready: false,
+};
+
+const App = () => {
+  const [authConfig, setAuthConfig] = useState({ enabled: false });
+  const [auth, setAuth] = useState(loadingAuthState);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadAuth = async () => {
+      const config = await loadOidcConfig();
+      if (!isMounted) {
+        return;
+      }
+      setAuthConfig(config);
+
+      try {
+        const tokenSet = await completeSignInIfNeeded(config);
+        if (isMounted) {
+          setAuth(buildAuthState(config, tokenSet));
+        }
+      } catch (error) {
+        if (isMounted) {
+          setAuth(buildAuthState(config, null, "Sign-in could not be completed."));
+        }
+      }
+    };
+
+    loadAuth();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleSignIn = () => {
+    startSignIn(authConfig).catch(() => {
+      setAuth(buildAuthState(authConfig, null, "Sign-in could not be started."));
+    });
+  };
+
+  const handleSignOut = () => {
+    signOut(authConfig);
+    setAuth(buildAuthState(authConfig, null));
+  };
+
+  return (
+    <div className="dashboard-layout">
+      <Topbar auth={auth} onSignIn={handleSignIn} onSignOut={handleSignOut} />
+      <div className="dashboard-body">
+        <Sidebar />
+        <MainContent auth={auth} />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default App;

--- a/services/polaris/src/App.test.js
+++ b/services/polaris/src/App.test.js
@@ -1,11 +1,12 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import App from "./App";
 
-test("renders the dashboard layout", () => {
+test("renders the dashboard layout", async () => {
   const { getByText } = render(<App />);
   expect(getByText("Polaris Mission Console")).toBeInTheDocument();
   expect(getByText("Dashboard")).toBeInTheDocument();
-  expect(getByText("Operational Dashboard")).toBeInTheDocument();
+  expect(getByText("Operator Cockpit")).toBeInTheDocument();
   expect(getByText("UniFi")).toBeInTheDocument();
+  expect(await screen.findByText("Sign-in not configured")).toBeInTheDocument();
 });

--- a/services/polaris/src/auth.js
+++ b/services/polaris/src/auth.js
@@ -1,0 +1,235 @@
+const CONFIG_URL = "/oidc-config.json";
+const TOKEN_STORAGE_KEY = "asterism.oidc.token";
+const VERIFIER_STORAGE_KEY = "asterism.oidc.verifier";
+const STATE_STORAGE_KEY = "asterism.oidc.state";
+
+export const disabledAuthState = {
+  ready: true,
+  enabled: false,
+  authenticated: false,
+  authorizationHeader: "",
+  principal: "",
+  error: "",
+};
+
+const base64Url = (bytes) => btoa(String.fromCharCode(...bytes))
+  .replace(/\+/g, "-")
+  .replace(/\//g, "_")
+  .replace(/=+$/, "");
+
+const randomString = (length = 48) => {
+  const bytes = new Uint8Array(length);
+  window.crypto.getRandomValues(bytes);
+  return base64Url(bytes);
+};
+
+const sha256 = async (value) => {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await window.crypto.subtle.digest("SHA-256", bytes);
+  return base64Url(new Uint8Array(digest));
+};
+
+const redirectUri = () => `${window.location.origin}${window.location.pathname}`;
+
+const normalizeConfig = (config) => {
+  if (!config || config.enabled !== true) {
+    return { enabled: false };
+  }
+
+  return {
+    enabled: true,
+    issuer: config.issuer || "",
+    clientId: config.clientId || "",
+    authorizationEndpoint: config.authorizationEndpoint || `${config.issuer}/oauth2/authorize`,
+    tokenEndpoint: config.tokenEndpoint || `${config.issuer}/oauth2/token`,
+    logoutEndpoint: config.logoutEndpoint || `${config.issuer}/logout`,
+    scopes: Array.isArray(config.scopes) && config.scopes.length > 0
+      ? config.scopes
+      : ["openid", "profile", "email"],
+  };
+};
+
+export const loadOidcConfig = async () => {
+  if (typeof fetch !== "function") {
+    return { enabled: false };
+  }
+
+  try {
+    const response = await fetch(CONFIG_URL, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      return { enabled: false };
+    }
+
+    return normalizeConfig(await response.json());
+  } catch (error) {
+    return { enabled: false };
+  }
+};
+
+const decodeJwtPayload = (token) => {
+  if (!token || !token.includes(".")) {
+    return {};
+  }
+
+  try {
+    const payload = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = payload.padEnd(payload.length + ((4 - (payload.length % 4)) % 4), "=");
+    return JSON.parse(atob(padded));
+  } catch (error) {
+    return {};
+  }
+};
+
+const tokenPrincipal = (tokenSet) => {
+  const payload = decodeJwtPayload(tokenSet.idToken || tokenSet.accessToken);
+  return payload.email || payload.name || payload["cognito:username"] || payload.sub || "";
+};
+
+const readStoredToken = () => {
+  try {
+    const raw = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const tokenSet = JSON.parse(raw);
+    if (!tokenSet.accessToken || !tokenSet.expiresAt || tokenSet.expiresAt <= Date.now() + 30000) {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+      return null;
+    }
+
+    return tokenSet;
+  } catch (error) {
+    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+    return null;
+  }
+};
+
+const storeToken = (payload) => {
+  const expiresIn = Number(payload.expires_in || 3600);
+  const tokenSet = {
+    accessToken: payload.access_token,
+    idToken: payload.id_token || "",
+    refreshToken: payload.refresh_token || "",
+    expiresAt: Date.now() + expiresIn * 1000,
+  };
+  window.localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokenSet));
+  return tokenSet;
+};
+
+const exchangeCode = async (config, code, verifier) => {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: config.clientId,
+    code,
+    code_verifier: verifier,
+    redirect_uri: redirectUri(),
+  });
+
+  const response = await fetch(config.tokenEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(`token exchange failed with HTTP ${response.status}`);
+  }
+
+  return storeToken(await response.json());
+};
+
+export const completeSignInIfNeeded = async (config) => {
+  if (!config.enabled) {
+    return null;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get("code");
+  const state = params.get("state");
+  if (!code || !state) {
+    return readStoredToken();
+  }
+
+  const expectedState = window.sessionStorage.getItem(STATE_STORAGE_KEY);
+  const verifier = window.sessionStorage.getItem(VERIFIER_STORAGE_KEY);
+  window.sessionStorage.removeItem(STATE_STORAGE_KEY);
+  window.sessionStorage.removeItem(VERIFIER_STORAGE_KEY);
+
+  if (state !== expectedState || !verifier) {
+    throw new Error("OIDC sign-in state did not match");
+  }
+
+  const tokenSet = await exchangeCode(config, code, verifier);
+  window.history.replaceState({}, document.title, redirectUri());
+  return tokenSet;
+};
+
+export const buildAuthState = (config, tokenSet, error = "") => {
+  if (!config.enabled) {
+    return disabledAuthState;
+  }
+
+  if (!tokenSet?.accessToken) {
+    return {
+      ready: true,
+      enabled: true,
+      authenticated: false,
+      authorizationHeader: "",
+      principal: "",
+      error,
+    };
+  }
+
+  return {
+    ready: true,
+    enabled: true,
+    authenticated: true,
+    authorizationHeader: `Bearer ${tokenSet.accessToken}`,
+    principal: tokenPrincipal(tokenSet),
+    error,
+  };
+};
+
+export const startSignIn = async (config) => {
+  if (!config.enabled || !config.clientId || !config.authorizationEndpoint) {
+    throw new Error("OIDC is not configured");
+  }
+
+  const verifier = randomString(64);
+  const state = randomString(32);
+  const challenge = await sha256(verifier);
+  window.sessionStorage.setItem(VERIFIER_STORAGE_KEY, verifier);
+  window.sessionStorage.setItem(STATE_STORAGE_KEY, state);
+
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    response_type: "code",
+    scope: config.scopes.join(" "),
+    redirect_uri: redirectUri(),
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    state,
+  });
+
+  window.location.assign(`${config.authorizationEndpoint}?${params.toString()}`);
+};
+
+export const signOut = (config) => {
+  window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  if (config.enabled && config.logoutEndpoint && config.clientId) {
+    const params = new URLSearchParams({
+      client_id: config.clientId,
+      logout_uri: redirectUri(),
+    });
+    window.location.assign(`${config.logoutEndpoint}?${params.toString()}`);
+  }
+};

--- a/services/polaris/src/components/MainContent.js
+++ b/services/polaris/src/components/MainContent.js
@@ -31,6 +31,37 @@ const STATUS_STATE = {
   ERROR: "error",
 };
 
+const severityFromSnapshot = (snapshot) => {
+  const integration = snapshot.payload?.integration || {};
+  if (integration.severity) {
+    return integration.severity;
+  }
+  if (snapshot.state === STATUS_STATE.ERROR) {
+    return "critical";
+  }
+  if (!integration.configured) {
+    return "unknown";
+  }
+  return integration.reachable ? "ok" : "critical";
+};
+
+const severityLabel = (severity) => {
+  if (severity === "ok") {
+    return "healthy";
+  }
+  if (severity === "warning") {
+    return "review";
+  }
+  if (severity === "critical") {
+    return "attention";
+  }
+  return "pending";
+};
+
+const authHeaders = (auth) => (
+  auth?.authorizationHeader ? { Authorization: auth.authorizationHeader } : {}
+);
+
 const buildFallbackCard = (service) => ({
   title: service.displayName,
   description: service.description,
@@ -160,7 +191,7 @@ const enrichService = async (service) => {
   }
 };
 
-const MainContent = () => {
+const MainContent = ({ auth = { ready: true, enabled: false } }) => {
   const [services, setServices] = useState(() => (
     FALLBACK_SERVICES.map((service) => ({
       ...service,
@@ -208,6 +239,19 @@ const MainContent = () => {
     if (typeof fetch !== "function") {
       return;
     }
+    if (!auth.ready) {
+      return;
+    }
+    if (auth.enabled && !auth.authenticated) {
+      setStatusByService(Object.fromEntries(services.map((service) => [
+        service.id,
+        {
+          state: STATUS_STATE.ERROR,
+          error: "Sign in required",
+        },
+      ])));
+      return;
+    }
 
     let isMounted = true;
 
@@ -223,6 +267,7 @@ const MainContent = () => {
         const response = await fetch(service.statusApi, {
           headers: {
             Accept: "application/json",
+            ...authHeaders(auth),
           },
         });
 
@@ -275,20 +320,25 @@ const MainContent = () => {
     return () => {
       isMounted = false;
     };
-  }, [services]);
+  }, [services, auth.ready, auth.enabled, auth.authenticated, auth.authorizationHeader]);
 
   const liveCount = useMemo(() => {
     const entries = Object.values(statusByService);
-    return entries.filter((entry) => entry?.state === STATUS_STATE.READY).length;
+    return entries.filter((entry) => severityFromSnapshot(entry) === "ok").length;
+  }, [statusByService]);
+
+  const reviewCount = useMemo(() => {
+    const entries = Object.values(statusByService);
+    return entries.filter((entry) => ["warning", "critical"].includes(severityFromSnapshot(entry))).length;
   }, [statusByService]);
 
   return (
     <main className="main-content" id="dashboard">
       <section className="hero-panel">
-        <h2>Operational Dashboard</h2>
+        <h2>Operator Cockpit</h2>
         <p>
-          Runtime microfrontend modules are resolved from service manifests and rendered as
-          live API-backed status cards.
+          Plain-language status from UniFi, pfSense, OpenShift, and GitOps, with backend-owned
+          configuration left in the systems that already manage it.
         </p>
         <div className="hero-stats">
           <div className="hero-stat">
@@ -297,7 +347,11 @@ const MainContent = () => {
           </div>
           <div className="hero-stat">
             <strong>{liveCount}</strong>
-            <span>Live Status Feeds</span>
+            <span>Healthy Services</span>
+          </div>
+          <div className="hero-stat">
+            <strong>{reviewCount}</strong>
+            <span>Need Review</span>
           </div>
         </div>
       </section>
@@ -309,29 +363,48 @@ const MainContent = () => {
           const metrics = integration.metrics && typeof integration.metrics === "object"
             ? integration.metrics
             : {};
+          const summary = integration.summary || {};
+          const stats = Array.isArray(summary.stats) ? summary.stats : [];
+          const highlights = Array.isArray(summary.highlights) ? summary.highlights : [];
+          const degradedReasons = Array.isArray(integration.degradedReasons) ? integration.degradedReasons : [];
+          const recommendedActions = Array.isArray(integration.recommendedActions) ? integration.recommendedActions : [];
+          const authoritativeLinks = Array.isArray(integration.authoritativeLinks) ? integration.authoritativeLinks : [];
+          const controls = Array.isArray(integration.controls) ? integration.controls : [];
+          const severity = severityFromSnapshot(snapshot);
           const card = service.card || buildFallbackCard(service);
 
           return (
-            <article className="service-card" key={service.id}>
+            <article className={`service-card service-card-${severity}`} key={service.id}>
               <div className="service-card-top">
                 <h3>{card.title}</h3>
-                <span className={`service-state service-state-${snapshot.state}`}>{snapshot.state}</span>
+                <span className={`service-state service-state-${severity}`}>{severityLabel(severity)}</span>
               </div>
 
-              <p>{card.description}</p>
+              <p>{summary.description || card.description}</p>
 
-              <div className="service-detail-row">
-                <span>Connectivity</span>
-                <strong>{integration.reachable ? "reachable" : integration.configured ? "degraded" : "not configured"}</strong>
-              </div>
-              <div className="service-detail-row">
-                <span>Latency</span>
-                <strong>{integration.latencyMs ? `${integration.latencyMs} ms` : "n/a"}</strong>
-              </div>
-              <div className="service-detail-row">
-                <span>HTTP</span>
-                <strong>{integration.httpStatus || "n/a"}</strong>
-              </div>
+              {stats.length > 0 && (
+                <div className="service-stat-grid">
+                  {stats.slice(0, 4).map((stat) => (
+                    <div className={`service-stat service-stat-${stat.state || "neutral"}`} key={`${service.id}-${stat.label}`}>
+                      <span>{stat.label}</span>
+                      <strong>{stat.value}{stat.unit ? ` ${stat.unit}` : ""}</strong>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {stats.length === 0 && (
+                <>
+                  <div className="service-detail-row">
+                    <span>Connectivity</span>
+                    <strong>{integration.reachable ? "reachable" : integration.configured ? "degraded" : "not configured"}</strong>
+                  </div>
+                  <div className="service-detail-row">
+                    <span>Latency</span>
+                    <strong>{integration.latencyMs ? `${integration.latencyMs} ms` : "n/a"}</strong>
+                  </div>
+                </>
+              )}
 
               {Object.keys(metrics).slice(0, 3).map((key) => (
                 <div className="service-detail-row" key={key}>
@@ -340,12 +413,62 @@ const MainContent = () => {
                 </div>
               ))}
 
+              <div className="service-detail-row">
+                <span>Last update</span>
+                <strong>{integration.observedAt ? new Date(integration.observedAt).toLocaleTimeString() : "waiting"}</strong>
+              </div>
+
               <p className="service-message">{integration.message || snapshot.error || "Waiting for first status poll."}</p>
-              {card.links.map((link) => (
-                <a href={link.href} key={`${service.id}-${link.href}`}>
-                  {link.label}
-                </a>
-              ))}
+
+              {highlights.length > 0 && (
+                <ul className="status-list">
+                  {highlights.slice(0, 3).map((item) => (
+                    <li key={`${service.id}-highlight-${item}`}>{item}</li>
+                  ))}
+                </ul>
+              )}
+
+              {degradedReasons.length > 0 && (
+                <div className="review-panel">
+                  <strong>Review</strong>
+                  <ul>
+                    {degradedReasons.slice(0, 3).map((reason) => (
+                      <li key={`${service.id}-reason-${reason}`}>{reason}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {recommendedActions.length > 0 && (
+                <div className="next-steps">
+                  {recommendedActions.slice(0, 2).map((action) => (
+                    <span key={`${service.id}-action-${action}`}>{action}</span>
+                  ))}
+                </div>
+              )}
+
+              {controls.length > 0 && (
+                <div className="control-row">
+                  {controls.slice(0, 2).map((control) => (
+                    <button
+                      type="button"
+                      disabled={!control.enabled}
+                      title={control.description}
+                      key={control.id}
+                    >
+                      {control.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              <div className="link-row">
+                {[...authoritativeLinks, ...card.links].slice(0, 3).map((link) => (
+                  <a href={link.href} key={`${service.id}-${link.href}`}>
+                    {link.label}
+                  </a>
+                ))}
+              </div>
             </article>
           );
         })}

--- a/services/polaris/src/components/MainContent.test.js
+++ b/services/polaris/src/components/MainContent.test.js
@@ -4,7 +4,7 @@ import MainContent from "./MainContent";
 
 test("renders welcome message", () => {
   const { getByText } = render(<MainContent />);
-  expect(getByText("Operational Dashboard")).toBeInTheDocument();
+  expect(getByText("Operator Cockpit")).toBeInTheDocument();
   expect(getByText("UniFi")).toBeInTheDocument();
   expect(getByText("OpenShift")).toBeInTheDocument();
   expect(getByText("pfSense")).toBeInTheDocument();
@@ -40,8 +40,8 @@ test("hydrates cards from service-owned module manifests", async () => {
           apiBasePath: "/api/services/unifi",
           uiBasePath: "/ui/services/unifi",
           dashboardCard: {
-            title: "UniFi Status",
-            description: "Runtime-loaded card owned by the unifi service.",
+            title: "UniFi Network",
+            description: "Wireless, network device, and client status from the local UniFi Network API.",
             statusEndpoint: "/api/v1/status",
             module: "/dashboard-card.js",
             export: "createDashboardCard",
@@ -74,8 +74,71 @@ test("hydrates cards from service-owned module manifests", async () => {
 
   render(<MainContent />);
 
-  expect(await screen.findByText("UniFi Status")).toBeInTheDocument();
-  expect(await screen.findByText("Runtime-loaded card owned by the unifi service.")).toBeInTheDocument();
+  expect(await screen.findByText("UniFi Network")).toBeInTheDocument();
+  expect(await screen.findByText("Wireless, network device, and client status from the local UniFi Network API.")).toBeInTheDocument();
+
+  global.fetch = originalFetch;
+});
+
+test("sends bearer token when fetching protected service status", async () => {
+  const originalFetch = global.fetch;
+  const statusFetches = [];
+
+  global.fetch = jest.fn((url, options = {}) => {
+    if (url === "/microfrontends.json") {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          services: [
+            {
+              id: "unifi",
+              displayName: "UniFi",
+              description: "Fallback description",
+              statusApi: "/api/services/unifi/api/v1/status",
+              moduleManifest: "/ui/services/unifi/module.json",
+            },
+          ],
+        }),
+      });
+    }
+
+    if (url === "/api/services/unifi/api/v1/status") {
+      statusFetches.push(options);
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          integration: {
+            configured: true,
+            reachable: true,
+            severity: "ok",
+            observedAt: "2026-05-05T12:00:00Z",
+            message: "UniFi Network is reachable.",
+            summary: {
+              stats: [
+                { label: "Devices online", value: "2/2", state: "ok" },
+              ],
+            },
+            metrics: {},
+          },
+        }),
+      });
+    }
+
+    return Promise.resolve({
+      ok: false,
+      json: async () => ({}),
+    });
+  });
+
+  render(<MainContent auth={{
+    ready: true,
+    enabled: true,
+    authenticated: true,
+    authorizationHeader: "Bearer test-token",
+  }} />);
+
+  expect(await screen.findByText("healthy")).toBeInTheDocument();
+  expect(statusFetches[0].headers.Authorization).toBe("Bearer test-token");
 
   global.fetch = originalFetch;
 });

--- a/services/polaris/src/components/Topbar.js
+++ b/services/polaris/src/components/Topbar.js
@@ -1,13 +1,34 @@
 import React from "react";
 
-const Topbar = () => (
+const authLabel = (auth) => {
+  if (!auth?.ready) {
+    return "Checking identity";
+  }
+  if (!auth.enabled) {
+    return "Sign-in not configured";
+  }
+  if (auth.authenticated) {
+    return auth.principal || "Signed in";
+  }
+  return "Sign-in required";
+};
+
+const Topbar = ({ auth, onSignIn, onSignOut }) => (
   <header className="topbar">
     <div>
       <p className="eyebrow">Asterism Control Plane</p>
       <h1>Polaris Mission Console</h1>
-      <p className="subtitle">API-first observability across home infrastructure services.</p>
+      <p className="subtitle">Read-first operations for home infrastructure, without shadow configuration.</p>
     </div>
-    <div className="status-pill">Runtime Composition Enabled</div>
+    <div className="identity-panel">
+      <span className="status-pill">{authLabel(auth)}</span>
+      {auth?.enabled && auth.authenticated && (
+        <button type="button" onClick={onSignOut}>Sign out</button>
+      )}
+      {auth?.enabled && !auth.authenticated && (
+        <button type="button" onClick={onSignIn}>Sign in</button>
+      )}
+    </div>
   </header>
 );
 

--- a/services/unifi/api/openapi.yaml
+++ b/services/unifi/api/openapi.yaml
@@ -10,6 +10,72 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  schemas:
+    GuidedAction:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        description:
+          type: string
+        risk:
+          type: string
+        enabled:
+          type: boolean
+        requiresApproval:
+          type: boolean
+        auditEvent:
+          type: string
+    IntegrationSnapshot:
+      type: object
+      properties:
+        configured:
+          type: boolean
+        reachable:
+          type: boolean
+        endpoint:
+          type: string
+        message:
+          type: string
+        httpStatus:
+          type: integer
+        latencyMs:
+          type: integer
+        observedAt:
+          type: string
+          format: date-time
+        severity:
+          type: string
+          enum: [ok, warning, critical, unknown]
+        degradedReasons:
+          type: array
+          items:
+            type: string
+        recommendedActions:
+          type: array
+          items:
+            type: string
+        authoritativeLinks:
+          type: array
+          items:
+            type: object
+            properties:
+              label:
+                type: string
+              href:
+                type: string
+        controls:
+          type: array
+          items:
+            $ref: '#/components/schemas/GuidedAction'
+        metrics:
+          type: object
+          additionalProperties: true
+        summary:
+          type: object
+          additionalProperties: true
 paths:
   /healthz:
     get:
@@ -37,23 +103,64 @@ paths:
                   principal:
                     type: string
                   integration:
-                    type: object
-                    properties:
-                      configured:
-                        type: boolean
-                      reachable:
-                        type: boolean
-                      endpoint:
-                        type: string
-                      message:
-                        type: string
-                      httpStatus:
-                        type: integer
-                      latencyMs:
-                        type: integer
-                      metrics:
-                        type: object
-                        additionalProperties: true
+                    $ref: '#/components/schemas/IntegrationSnapshot'
+                  timestamp:
+                    type: string
+                    format: date-time
+        '401':
+          description: Missing identity context
+        '403':
+          description: Authenticated but not authorized
+  /api/v1/summary:
+    get:
+      summary: Return read-only UniFi operator summary
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Current operator summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  status:
+                    type: string
+                  principal:
+                    type: string
+                  integration:
+                    $ref: '#/components/schemas/IntegrationSnapshot'
+                  timestamp:
+                    type: string
+                    format: date-time
+        '401':
+          description: Missing identity context
+        '403':
+          description: Authenticated but not authorized
+  /api/v1/actions:
+    get:
+      summary: Return available guided action contracts
+      description: Actions are advertised for UX and automation planning only; this endpoint does not mutate UniFi.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Guided action catalog
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  service:
+                    type: string
+                  principal:
+                    type: string
+                  actions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/GuidedAction'
                   timestamp:
                     type: string
                     format: date-time

--- a/services/unifi/deploy/base/deployment.yaml
+++ b/services/unifi/deploy/base/deployment.yaml
@@ -29,8 +29,30 @@ spec:
               value: "enforced"
             - name: AUTH_REQUIRED_GROUP
               value: ""
-            - name: UNIFI_API_URL
-              value: ""
+            - name: UNIFI_API_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: unifi-secrets
+                  key: apiBaseUrl
+                  optional: true
+            - name: UNIFI_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: unifi-secrets
+                  key: apiToken
+                  optional: true
+            - name: UNIFI_SITE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: unifi-secrets
+                  key: siteId
+                  optional: true
+            - name: UNIFI_CONSOLE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: unifi-secrets
+                  key: consoleUrl
+                  optional: true
           livenessProbe:
             httpGet:
               path: /healthz

--- a/services/unifi/deploy/base/externalsecret.yaml
+++ b/services/unifi/deploy/base/externalsecret.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: unifi-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secretsmanager
+  target:
+    name: unifi-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: apiBaseUrl
+      remoteRef:
+        key: /asterism/unifi
+        property: apiBaseUrl
+    - secretKey: apiToken
+      remoteRef:
+        key: /asterism/unifi
+        property: apiToken
+    - secretKey: siteId
+      remoteRef:
+        key: /asterism/unifi
+        property: siteId
+    - secretKey: consoleUrl
+      remoteRef:
+        key: /asterism/unifi
+        property: consoleUrl

--- a/services/unifi/deploy/kustomization.yaml
+++ b/services/unifi/deploy/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: asterism
 resources:
   - ./base/deployment.yaml
   - ./base/service.yaml
+  - ./base/externalsecret.yaml
 images:
   - name: unifi
     newName: ghcr.io/jlfowle/asterism-unifi

--- a/services/unifi/internal/api/handlers.go
+++ b/services/unifi/internal/api/handlers.go
@@ -33,6 +33,8 @@ func (h Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(http.FS(uiassets.Files))))
 	mux.HandleFunc("/healthz", h.healthz)
 	mux.Handle("/api/v1/status", h.auth.Protect(http.HandlerFunc(h.status)))
+	mux.Handle("/api/v1/summary", h.auth.Protect(http.HandlerFunc(h.status)))
+	mux.Handle("/api/v1/actions", h.auth.Protect(http.HandlerFunc(h.actions)))
 }
 
 func (h Handler) healthz(w http.ResponseWriter, _ *http.Request) {
@@ -48,6 +50,24 @@ func (h Handler) status(w http.ResponseWriter, r *http.Request) {
 		Principal:   principalFromContext(r.Context()),
 		Integration: integration.Probe(r.Context()),
 		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h Handler) actions(w http.ResponseWriter, r *http.Request) {
+	resp := struct {
+		Service   string                `json:"service"`
+		Principal string                `json:"principal,omitempty"`
+		Actions   []integration.Control `json:"actions"`
+		Timestamp string                `json:"timestamp"`
+	}{
+		Service:   h.serviceName,
+		Principal: principalFromContext(r.Context()),
+		Actions:   integration.Actions(),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/services/unifi/internal/api/handlers_test.go
+++ b/services/unifi/internal/api/handlers_test.go
@@ -13,6 +13,14 @@ type statusTestResponse struct {
 	Principal string `json:"principal"`
 }
 
+type actionsTestResponse struct {
+	Service string `json:"service"`
+	Actions []struct {
+		ID      string `json:"id"`
+		Enabled bool   `json:"enabled"`
+	} `json:"actions"`
+}
+
 func TestHealthz(t *testing.T) {
 	h := NewHandler("unifi")
 	mux := http.NewServeMux()
@@ -77,7 +85,7 @@ func TestStatusUnauthorizedWhenMissingPrincipal(t *testing.T) {
 func TestStatusAuthorizedWithPrincipal(t *testing.T) {
 	t.Setenv("AUTH_MODE", "enforced")
 	t.Setenv("AUTH_REQUIRED_GROUP", "")
-	t.Setenv("UNIFI_API_URL", "")
+	t.Setenv("UNIFI_API_BASE_URL", "")
 
 	h := NewHandler("unifi")
 	mux := http.NewServeMux()
@@ -104,5 +112,39 @@ func TestStatusAuthorizedWithPrincipal(t *testing.T) {
 
 	if payload.Principal != "test-user" {
 		t.Fatalf("expected principal %q, got %q", "test-user", payload.Principal)
+	}
+}
+
+func TestActionsAuthorizedWithPrincipal(t *testing.T) {
+	t.Setenv("AUTH_MODE", "enforced")
+	t.Setenv("AUTH_REQUIRED_GROUP", "")
+
+	h := NewHandler("unifi")
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil)
+	req.Header.Set("X-Asterism-Principal", "test-user")
+
+	res := httptest.NewRecorder()
+	mux.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+
+	var payload actionsTestResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to unmarshal actions response: %v", err)
+	}
+
+	if payload.Service != "unifi" {
+		t.Fatalf("expected service %q, got %q", "unifi", payload.Service)
+	}
+	if len(payload.Actions) == 0 {
+		t.Fatalf("expected guided action contracts")
+	}
+	if payload.Actions[0].Enabled {
+		t.Fatalf("expected guided actions to be disabled in observe-first milestone")
 	}
 }

--- a/services/unifi/internal/integration/probe.go
+++ b/services/unifi/internal/integration/probe.go
@@ -6,101 +6,462 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
 type Snapshot struct {
-	Configured bool   `json:"configured"`
-	Reachable  bool   `json:"reachable"`
-	Endpoint   string `json:"endpoint,omitempty"`
-	Message    string `json:"message"`
-	HTTPStatus int    `json:"httpStatus,omitempty"`
-	LatencyMs  int64  `json:"latencyMs,omitempty"`
-	Metrics    any    `json:"metrics,omitempty"`
+	Configured         bool      `json:"configured"`
+	Reachable          bool      `json:"reachable"`
+	Endpoint           string    `json:"endpoint,omitempty"`
+	Message            string    `json:"message"`
+	HTTPStatus         int       `json:"httpStatus,omitempty"`
+	LatencyMs          int64     `json:"latencyMs,omitempty"`
+	ObservedAt         string    `json:"observedAt"`
+	Severity           string    `json:"severity"`
+	DegradedReasons    []string  `json:"degradedReasons,omitempty"`
+	RecommendedActions []string  `json:"recommendedActions,omitempty"`
+	AuthoritativeLinks []Link    `json:"authoritativeLinks,omitempty"`
+	Controls           []Control `json:"controls,omitempty"`
+	Metrics            any       `json:"metrics,omitempty"`
+	Summary            Summary   `json:"summary,omitempty"`
+}
+
+type Summary struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Stats       []Stat   `json:"stats,omitempty"`
+	Highlights  []string `json:"highlights,omitempty"`
+}
+
+type Stat struct {
+	Label string `json:"label"`
+	Value string `json:"value"`
+	Unit  string `json:"unit,omitempty"`
+	State string `json:"state,omitempty"`
+}
+
+type Link struct {
+	Label string `json:"label"`
+	Href  string `json:"href"`
+}
+
+type Control struct {
+	ID               string `json:"id"`
+	Label            string `json:"label"`
+	Description      string `json:"description"`
+	Risk             string `json:"risk"`
+	Enabled          bool   `json:"enabled"`
+	RequiresApproval bool   `json:"requiresApproval"`
+	AuditEvent       string `json:"auditEvent"`
+}
+
+type Config struct {
+	BaseURL    string
+	Token      string
+	Site       string
+	ConsoleURL string
+	APIPrefix  string
+}
+
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type unifiEnvelope struct {
+	Data []map[string]any `json:"data"`
 }
 
 func Probe(ctx context.Context) Snapshot {
-	endpoint := os.Getenv("UNIFI_API_URL")
-	token := os.Getenv("UNIFI_API_TOKEN")
+	return ProbeWithClient(ctx, http.DefaultClient, ConfigFromEnv())
+}
 
-	if endpoint == "" {
+func ConfigFromEnv() Config {
+	baseURL := firstNonEmpty(os.Getenv("UNIFI_API_BASE_URL"), os.Getenv("UNIFI_API_URL"))
+	site := strings.TrimSpace(os.Getenv("UNIFI_SITE_ID"))
+	if site == "" {
+		site = "default"
+	}
+
+	return Config{
+		BaseURL:    strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		Token:      strings.TrimSpace(os.Getenv("UNIFI_API_TOKEN")),
+		Site:       site,
+		ConsoleURL: strings.TrimSpace(os.Getenv("UNIFI_CONSOLE_URL")),
+		APIPrefix:  strings.TrimSpace(os.Getenv("UNIFI_NETWORK_API_PREFIX")),
+	}
+}
+
+func ProbeWithClient(ctx context.Context, client HTTPDoer, cfg Config) Snapshot {
+	observedAt := time.Now().UTC().Format(time.RFC3339)
+
+	if cfg.BaseURL == "" {
 		return Snapshot{
-			Configured: false,
-			Reachable:  false,
-			Message:    "integration not configured",
+			Configured:         false,
+			Reachable:          false,
+			Message:            "UniFi is not connected to Asterism yet.",
+			ObservedAt:         observedAt,
+			Severity:           "unknown",
+			RecommendedActions: []string{"Add the local UniFi Network API base URL and read-only token through External Secrets."},
+			Controls:           Actions(),
+			Summary: Summary{
+				Title:       "UniFi needs connection details",
+				Description: "Asterism can explain wireless and client status after the local UniFi Network API is configured.",
+			},
 		}
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
+	startedAt := time.Now()
+	deviceItems, deviceStatus, deviceErr := getUniFiItems(ctx, client, cfg, "stat/device")
+	clientItems, _, clientErr := getUniFiItems(ctx, client, cfg, "stat/sta")
+	latencyMs := time.Since(startedAt).Milliseconds()
+	if deviceErr != nil {
 		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("failed to create request: %v", err),
+			Configured:         true,
+			Reachable:          false,
+			Endpoint:           cfg.BaseURL,
+			Message:            fmt.Sprintf("UniFi Network API request failed: %v", deviceErr),
+			HTTPStatus:         deviceStatus,
+			LatencyMs:          latencyMs,
+			ObservedAt:         observedAt,
+			Severity:           "critical",
+			DegradedReasons:    []string{"Asterism could not read UniFi device status."},
+			RecommendedActions: []string{"Confirm the UniFi Network API base URL, token, and site identifier."},
+			AuthoritativeLinks: authoritativeLinks(cfg),
+			Controls:           Actions(),
+			Summary: Summary{
+				Title:       "UniFi is unreachable",
+				Description: "Wireless status is unavailable until the local UniFi Network API responds.",
+			},
 		}
 	}
 
+	deviceSummary := summarizeDevices(deviceItems)
+	clientSummary := summarizeClients(clientItems)
+	reasons := degradedReasons(deviceSummary, clientErr)
+	severity := "ok"
+	message := "UniFi Network is reachable."
+	if len(reasons) > 0 {
+		severity = "warning"
+		message = "UniFi Network is reachable with items to review."
+	}
+
+	metrics := map[string]any{
+		"site":                cfg.Site,
+		"deviceCount":         deviceSummary.Total,
+		"onlineDeviceCount":   deviceSummary.Online,
+		"offlineDeviceCount":  deviceSummary.Offline,
+		"updateDeviceCount":   deviceSummary.PendingUpdates,
+		"accessPointCount":    deviceSummary.AccessPoints,
+		"switchCount":         deviceSummary.Switches,
+		"gatewayCount":        deviceSummary.Gateways,
+		"clientCount":         clientSummary.Total,
+		"wifiClientCount":     clientSummary.Wifi,
+		"wiredClientCount":    clientSummary.Wired,
+		"guestClientCount":    clientSummary.Guests,
+		"clientsFetchSuccess": clientErr == nil,
+		"statusClass":         fmt.Sprintf("%dxx", deviceStatus/100),
+	}
+
+	return Snapshot{
+		Configured:         true,
+		Reachable:          true,
+		Endpoint:           cfg.BaseURL,
+		Message:            message,
+		HTTPStatus:         deviceStatus,
+		LatencyMs:          latencyMs,
+		ObservedAt:         observedAt,
+		Severity:           severity,
+		DegradedReasons:    reasons,
+		RecommendedActions: recommendedActions(reasons),
+		AuthoritativeLinks: authoritativeLinks(cfg),
+		Controls:           Actions(),
+		Metrics:            metrics,
+		Summary: Summary{
+			Title:       "UniFi Network overview",
+			Description: "Read-only status from the local UniFi Network API.",
+			Stats: []Stat{
+				{Label: "Devices online", Value: fmt.Sprintf("%d/%d", deviceSummary.Online, deviceSummary.Total), State: stateForZero(deviceSummary.Offline)},
+				{Label: "Clients", Value: strconv.Itoa(clientSummary.Total), State: "ok"},
+				{Label: "Wi-Fi clients", Value: strconv.Itoa(clientSummary.Wifi), State: "ok"},
+				{Label: "Pending updates", Value: strconv.Itoa(deviceSummary.PendingUpdates), State: stateForZero(deviceSummary.PendingUpdates)},
+			},
+			Highlights: highlights(deviceSummary, clientSummary, clientErr),
+		},
+	}
+}
+
+func Actions() []Control {
+	return []Control{
+		{
+			ID:               "unifi.pause-guest-wifi",
+			Label:            "Pause guest Wi-Fi",
+			Description:      "Future guided action that would ask UniFi to pause a selected guest WLAN through its own API.",
+			Risk:             "medium",
+			Enabled:          false,
+			RequiresApproval: true,
+			AuditEvent:       "unifi.guided_action.pause_guest_wifi",
+		},
+		{
+			ID:               "unifi.restart-access-point",
+			Label:            "Restart access point",
+			Description:      "Future guided action for a selected AP, with confirmation and audit logging.",
+			Risk:             "medium",
+			Enabled:          false,
+			RequiresApproval: true,
+			AuditEvent:       "unifi.guided_action.restart_access_point",
+		},
+	}
+}
+
+func getUniFiItems(ctx context.Context, client HTTPDoer, cfg Config, resource string) ([]map[string]any, int, error) {
+	var lastStatus int
+	var lastErr error
+	for _, prefix := range apiPrefixes(cfg) {
+		requestURL, err := joinUniFiURL(cfg.BaseURL, prefix, cfg.Site, resource)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		items, status, err := requestItems(ctx, client, requestURL, cfg.Token)
+		lastStatus = status
+		if err == nil {
+			return items, status, nil
+		}
+		lastErr = err
+	}
+
+	return nil, lastStatus, lastErr
+}
+
+func requestItems(ctx context.Context, client HTTPDoer, requestURL string, token string) ([]map[string]any, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Accept", "application/json")
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	startedAt := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
-		return Snapshot{
-			Configured: true,
-			Reachable:  false,
-			Endpoint:   endpoint,
-			Message:    fmt.Sprintf("request failed: %v", err),
-		}
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 
-	latencyMs := time.Since(startedAt).Milliseconds()
-	metrics := map[string]any{
-		"statusClass": fmt.Sprintf("%dxx", resp.StatusCode/100),
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		return nil, resp.StatusCode, fmt.Errorf("upstream returned status %d", resp.StatusCode)
 	}
 
-	contentType := resp.Header.Get("Content-Type")
-	if strings.Contains(contentType, "application/json") {
-		bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		if readErr == nil {
-			var payload map[string]any
-			if unmarshalErr := json.Unmarshal(bodyBytes, &payload); unmarshalErr == nil {
-				for _, key := range []string{"name", "version", "status", "uptime"} {
-					if value, exists := payload[key]; exists {
-						metrics[key] = value
-					}
-				}
-			}
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+
+	var envelope unifiEnvelope
+	if err := json.Unmarshal(bodyBytes, &envelope); err == nil && envelope.Data != nil {
+		return envelope.Data, resp.StatusCode, nil
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal(bodyBytes, &items); err == nil {
+		return items, resp.StatusCode, nil
+	}
+
+	return nil, resp.StatusCode, fmt.Errorf("unexpected UniFi response shape")
+}
+
+type deviceCounts struct {
+	Total          int
+	Online         int
+	Offline        int
+	PendingUpdates int
+	AccessPoints   int
+	Switches       int
+	Gateways       int
+}
+
+func summarizeDevices(items []map[string]any) deviceCounts {
+	var counts deviceCounts
+	for _, item := range items {
+		counts.Total++
+		if intField(item, "state") == 1 || stringField(item, "state") == "CONNECTED" {
+			counts.Online++
+		} else {
+			counts.Offline++
+		}
+		if boolField(item, "upgradable") || boolField(item, "upgradeable") {
+			counts.PendingUpdates++
+		}
+		switch strings.ToLower(stringField(item, "type")) {
+		case "uap":
+			counts.AccessPoints++
+		case "usw":
+			counts.Switches++
+		case "ugw", "uxg":
+			counts.Gateways++
 		}
 	}
+	return counts
+}
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
-		return Snapshot{
-			Configured: true,
-			Reachable:  true,
-			Endpoint:   endpoint,
-			Message:    "upstream API reachable",
-			HTTPStatus: resp.StatusCode,
-			LatencyMs:  latencyMs,
-			Metrics:    metrics,
+type clientCounts struct {
+	Total  int
+	Wifi   int
+	Wired  int
+	Guests int
+}
+
+func summarizeClients(items []map[string]any) clientCounts {
+	var counts clientCounts
+	for _, item := range items {
+		counts.Total++
+		if boolField(item, "is_wired") {
+			counts.Wired++
+		} else {
+			counts.Wifi++
+		}
+		if boolField(item, "is_guest") {
+			counts.Guests++
 		}
 	}
+	return counts
+}
 
-	return Snapshot{
-		Configured: true,
-		Reachable:  false,
-		Endpoint:   endpoint,
-		Message:    fmt.Sprintf("upstream returned status %d", resp.StatusCode),
-		HTTPStatus: resp.StatusCode,
-		LatencyMs:  latencyMs,
-		Metrics:    metrics,
+func degradedReasons(devices deviceCounts, clientErr error) []string {
+	reasons := make([]string, 0)
+	if devices.Offline > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d UniFi device(s) appear offline.", devices.Offline))
 	}
+	if devices.PendingUpdates > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d UniFi device(s) have updates available.", devices.PendingUpdates))
+	}
+	if clientErr != nil {
+		reasons = append(reasons, "Client telemetry could not be read.")
+	}
+	return reasons
+}
+
+func recommendedActions(reasons []string) []string {
+	if len(reasons) == 0 {
+		return []string{"No operator action is needed right now."}
+	}
+	return []string{"Open UniFi Network to inspect affected devices before making changes."}
+}
+
+func highlights(devices deviceCounts, clients clientCounts, clientErr error) []string {
+	items := []string{
+		fmt.Sprintf("%d of %d UniFi devices are online.", devices.Online, devices.Total),
+		fmt.Sprintf("%d active clients are visible to Asterism.", clients.Total),
+	}
+	if clientErr != nil {
+		items = append(items, "Client details are stale or unavailable.")
+	}
+	return items
+}
+
+func authoritativeLinks(cfg Config) []Link {
+	target := cfg.ConsoleURL
+	if target == "" {
+		target = cfg.BaseURL
+	}
+	if target == "" {
+		return nil
+	}
+	return []Link{{Label: "Open UniFi Network", Href: target}}
+}
+
+func apiPrefixes(cfg Config) []string {
+	if cfg.APIPrefix != "" {
+		return []string{cfg.APIPrefix}
+	}
+	return []string{"/proxy/network/api", "/api"}
+}
+
+func joinUniFiURL(baseURL string, prefix string, site string, resource string) (string, error) {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("base URL must include scheme and host")
+	}
+
+	prefix = strings.Trim(prefix, "/")
+	resource = strings.Trim(resource, "/")
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/" + prefix + "/s/" + url.PathEscape(site) + "/" + resource
+	return parsed.String(), nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringField(item map[string]any, key string) string {
+	value, ok := item[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	default:
+		return fmt.Sprintf("%v", typed)
+	}
+}
+
+func boolField(item map[string]any, key string) bool {
+	value, ok := item[key]
+	if !ok || value == nil {
+		return false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return typed == "true" || typed == "1"
+	default:
+		return fmt.Sprintf("%v", typed) == "1"
+	}
+}
+
+func intField(item map[string]any, key string) int {
+	value, ok := item[key]
+	if !ok || value == nil {
+		return 0
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case float64:
+		return int(typed)
+	case json.Number:
+		parsed, _ := typed.Int64()
+		return int(parsed)
+	case string:
+		parsed, _ := strconv.Atoi(typed)
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func stateForZero(value int) string {
+	if value == 0 {
+		return "ok"
+	}
+	return "warning"
 }

--- a/services/unifi/internal/integration/probe_test.go
+++ b/services/unifi/internal/integration/probe_test.go
@@ -1,0 +1,58 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbeWithClientSummarizesUniFiNetwork(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/proxy/network/api/s/default/stat/device":
+			_, _ = fmt.Fprint(w, `{"data":[{"type":"uap","state":1},{"type":"usw","state":0,"upgradable":true}]}`)
+		case "/proxy/network/api/s/default/stat/sta":
+			_, _ = fmt.Fprint(w, `{"data":[{"is_wired":false},{"is_wired":true,"is_guest":true}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	snapshot := ProbeWithClient(context.Background(), server.Client(), Config{
+		BaseURL: server.URL,
+		Site:    "default",
+	})
+
+	if !snapshot.Configured || !snapshot.Reachable {
+		t.Fatalf("expected reachable configured snapshot, got %#v", snapshot)
+	}
+	if snapshot.Severity != "warning" {
+		t.Fatalf("expected warning severity for offline/update device, got %q", snapshot.Severity)
+	}
+
+	metrics := snapshot.Metrics.(map[string]any)
+	if metrics["deviceCount"] != 2 {
+		t.Fatalf("expected two devices, got %#v", metrics["deviceCount"])
+	}
+	if metrics["clientCount"] != 2 {
+		t.Fatalf("expected two clients, got %#v", metrics["clientCount"])
+	}
+	if len(snapshot.Controls) == 0 {
+		t.Fatalf("expected guided action contracts")
+	}
+}
+
+func TestProbeWithClientReportsUnconfiguredUniFi(t *testing.T) {
+	snapshot := ProbeWithClient(context.Background(), http.DefaultClient, Config{})
+
+	if snapshot.Configured {
+		t.Fatalf("expected unconfigured snapshot")
+	}
+	if snapshot.Severity != "unknown" {
+		t.Fatalf("expected unknown severity, got %q", snapshot.Severity)
+	}
+}

--- a/services/unifi/ui/dashboard-card.js
+++ b/services/unifi/ui/dashboard-card.js
@@ -4,7 +4,7 @@ export function createDashboardCard({ title, description, statusApi }) {
     description,
     links: [
       {
-        label: "View status API",
+        label: "Status API",
         href: statusApi,
       },
     ],

--- a/services/unifi/ui/module.json
+++ b/services/unifi/ui/module.json
@@ -5,9 +5,10 @@
   "apiBasePath": "/api/services/unifi",
   "uiBasePath": "/ui/services/unifi",
   "dashboardCard": {
-    "title": "UniFi Status",
-    "description": "Runtime-loaded card owned by the unifi service.",
+    "title": "UniFi Network",
+    "description": "Wireless, network device, and client status from the local UniFi Network API.",
     "statusEndpoint": "/api/v1/status",
+    "actionsEndpoint": "/api/v1/actions",
     "module": "/dashboard-card.js",
     "export": "createDashboardCard"
   }


### PR DESCRIPTION
## Summary
- Adds read-first operator cockpit summaries for UniFi, pfSense, and OpenShift/Argo CD.
- Adds protected `/api/v1/summary` and `/api/v1/actions` contracts with disabled guided action metadata.
- Wires UniFi/pfSense ExternalSecret references, dedicated Cluster read-only RBAC, and Polaris runtime OIDC config plus bearer-token service fetches.
- Updates Polaris cards and durable docs around the operator cockpit boundary: expose status and safe action contracts without replacing backend configuration authority.

## Validation
- `make test`
- `make lint`
- `make build`
- `make render-deploy`

## Notes
- The PR is observe-first: no mutating backend action endpoint is implemented.
- Real Cognito and AWS Secrets Manager store values still need to be provided by platform/GitOps configuration.