### PR TITLE
feat(authz): package-first authorizer, integrate service middleware

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,6 +176,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}-${{ matrix.service.id }}:${{ needs.metadata.outputs.version }}
           outputs: type=docker,dest=${{ runner.temp }}/image-${{ matrix.service.id }}.tar
+          build-contexts: pkg=pkg
           build-args: |
             VERSION=${{ needs.metadata.outputs.version }}
             BUILD_DATE=${{ github.event.pull_request.updated_at || github.run_id }}

--- a/pkg/authz/authorizer.go
+++ b/pkg/authz/authorizer.go
@@ -1,0 +1,25 @@
+package authz
+
+import (
+    "context"
+    "os"
+    "strings"
+)
+
+// Authorizer decides whether a principal is allowed to perform an action.
+type Authorizer interface {
+    // IsAllowed returns allowed (bool), a human reason string when denied, and an error for internal failures.
+    IsAllowed(ctx context.Context, principal string, groups []string, resource string, verb string) (bool, string, error)
+}
+
+// NewAuthorizer chooses an implementation based on environment configuration.
+// If AUTHZ_OPA_URL is set, an OPA-backed authorizer will be used. Otherwise a
+// simple local group-based authorizer is returned.
+func NewAuthorizer(requiredGroup string) Authorizer {
+    opa := strings.TrimSpace(os.Getenv("AUTHZ_OPA_URL"))
+    if opa != "" {
+        return NewOPAAuthorizer(opa, requiredGroup)
+    }
+
+    return &LocalAuthorizer{requiredGroup: strings.TrimSpace(requiredGroup)}
+}

--- a/pkg/authz/go.mod
+++ b/pkg/authz/go.mod
@@ -1,0 +1,3 @@
+module github.com/jlfowle/asterism/pkg/authz
+
+go 1.23

--- a/pkg/authz/local_authorizer.go
+++ b/pkg/authz/local_authorizer.go
@@ -1,0 +1,26 @@
+package authz
+
+import (
+    "context"
+)
+
+// LocalAuthorizer implements a minimal group-based check.
+type LocalAuthorizer struct{
+    requiredGroup string
+}
+
+// IsAllowed returns true when no required group is configured or when the
+// principal's groups contain the required group.
+func (l *LocalAuthorizer) IsAllowed(ctx context.Context, principal string, groups []string, resource string, verb string) (bool, string, error) {
+    if l.requiredGroup == "" {
+        return true, "", nil
+    }
+
+    for _, g := range groups {
+        if g == l.requiredGroup {
+            return true, "", nil
+        }
+    }
+
+    return false, "missing required group", nil
+}

--- a/pkg/authz/opa_authorizer.go
+++ b/pkg/authz/opa_authorizer.go
@@ -1,0 +1,90 @@
+package authz
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "strings"
+    "time"
+)
+
+type OPAAuthorizer struct{
+    endpoint string
+    client   *http.Client
+    requiredGroup string
+}
+
+// NewOPAAuthorizer constructs an OPAAuthorizer. If the provided URL does not
+// contain a v1 path, the typical OPA data path for `asterism/authz/allow` is
+// appended.
+func NewOPAAuthorizer(rawURL string, requiredGroup string) Authorizer {
+    endpoint := strings.TrimSpace(rawURL)
+    if !strings.Contains(endpoint, "/v1/") {
+        endpoint = strings.TrimRight(endpoint, "/") + "/v1/data/asterism/authz/allow"
+    }
+
+    return &OPAAuthorizer{
+        endpoint: endpoint,
+        client: &http.Client{Timeout: 2 * time.Second},
+        requiredGroup: strings.TrimSpace(requiredGroup),
+    }
+}
+
+// IsAllowed calls OPA with the input and expects a JSON response. It understands
+// either `{"result": true}` or `{"result": {"allow": true}}` shapes.
+func (o *OPAAuthorizer) IsAllowed(ctx context.Context, principal string, groups []string, resource string, verb string) (bool, string, error) {
+    input := map[string]any{"input": map[string]any{"principal": principal, "groups": groups, "resource": resource, "verb": verb}}
+
+    reqBody, err := json.Marshal(input)
+    if err != nil {
+        return false, "internal error", err
+    }
+
+    req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.endpoint, strings.NewReader(string(reqBody)))
+    if err != nil {
+        return false, "internal error", err
+    }
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := o.client.Do(req)
+    if err != nil {
+        return false, "authorization backend error", err
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+        return false, fmt.Sprintf("authorization backend returned %d", resp.StatusCode), nil
+    }
+
+    var buf map[string]any
+    if err := json.NewDecoder(resp.Body).Decode(&buf); err != nil {
+        return false, "invalid authorization response", err
+    }
+
+    // inspect buf["result"]
+    if res, ok := buf["result"]; ok {
+        switch v := res.(type) {
+        case bool:
+            if v { return true, "", nil }
+            return false, "denied", nil
+        case map[string]any:
+            if allow, ok := v["allow"].(bool); ok {
+                if allow { return true, "", nil }
+                return false, "denied", nil
+            }
+        }
+    }
+
+    // fallback: if OPA did not allow and we have a requiredGroup, enforce local group check
+    if o.requiredGroup != "" {
+        for _, g := range groups {
+            if g == o.requiredGroup {
+                return true, "", nil
+            }
+        }
+        return false, "missing required group", nil
+    }
+
+    return false, "denied", nil
+}

--- a/services/cluster/Dockerfile
+++ b/services/cluster/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.26-bookworm AS build
 
-WORKDIR /src
+COPY --from=pkg . /src/pkg
+
+WORKDIR /src/services/cluster
 COPY go.mod ./
 COPY . .
 

--- a/services/cluster/deploy/base/rbac.yaml
+++ b/services/cluster/deploy/base/rbac.yaml
@@ -1,30 +1,10 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: asterism-cluster-readonly
-rules:
-  - apiGroups: [""]
-    resources: ["nodes", "namespaces", "pods", "services"]
-    verbs: ["get", "list"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
-    verbs: ["get", "list"]
-  - apiGroups: ["config.openshift.io"]
-    resources: ["clusterversions", "clusteroperators"]
-    verbs: ["get", "list"]
-  - apiGroups: ["argoproj.io"]
-    resources: ["applications"]
-    verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: asterism-cluster-readonly
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: asterism-cluster-readonly
-subjects:
-  - kind: ServiceAccount
-    name: cluster
-    namespace: asterism
+  name: asterism-cluster-rbac-moved
+  namespace: asterism
+data:
+  note: |
+    The cluster-scoped ClusterRole/ClusterRoleBinding previously lived here.
+    Cluster-scoped RBAC must be owned and applied from the platform repo (os-config).
+    See os-config/cluster/asterism-rbac/asterism-cluster-readonly.yaml for the moved resource.

--- a/services/cluster/go.mod
+++ b/services/cluster/go.mod
@@ -1,3 +1,7 @@
 module github.com/jlfowle/asterism/services/cluster
 
 go 1.23
+
+replace github.com/jlfowle/asterism/pkg/authz => ../../pkg/authz
+
+require github.com/jlfowle/asterism/pkg/authz v0.0.0-00010101000000-000000000000 // indirect

--- a/services/cluster/internal/api/auth.go
+++ b/services/cluster/internal/api/auth.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
-	"slices"
 	"strings"
+
+	"github.com/jlfowle/asterism/pkg/authz"
 )
 
 type contextKey string
@@ -15,6 +17,7 @@ const principalContextKey contextKey = "principal"
 type AuthMiddleware struct {
 	mode          string
 	requiredGroup string
+	authorizer    authz.Authorizer
 }
 
 func NewAuthMiddlewareFromEnv() AuthMiddleware {
@@ -28,6 +31,7 @@ func NewAuthMiddlewareFromEnv() AuthMiddleware {
 	return AuthMiddleware{
 		mode:          mode,
 		requiredGroup: requiredGroup,
+		authorizer:    authz.NewAuthorizer(requiredGroup),
 	}
 }
 
@@ -46,8 +50,13 @@ func (a AuthMiddleware) Protect(next http.Handler) http.Handler {
 
 		if a.requiredGroup != "" {
 			groups := a.readGroups(r)
-			if !slices.Contains(groups, a.requiredGroup) {
-				http.Error(w, "missing required group", http.StatusForbidden)
+			allowed, reason, err := a.authorizer.IsAllowed(r.Context(), principal, groups, r.URL.Path, r.Method)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("authorization error: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if !allowed {
+				http.Error(w, reason, http.StatusForbidden)
 				return
 			}
 		}

--- a/services/cluster/internal/authz/authorizer.go
+++ b/services/cluster/internal/authz/authorizer.go
@@ -1,0 +1,18 @@
+package authz
+
+import (
+    "context"
+    "strings"
+)
+
+// Authorizer decides whether a principal is allowed to perform an action.
+type Authorizer interface {
+    // IsAllowed returns allowed (bool), a human reason string when denied, and an error for internal failures.
+    IsAllowed(ctx context.Context, principal string, groups []string, resource string, verb string) (bool, string, error)
+}
+
+// NewAuthorizer returns a simple local authorizer. In future this factory
+// may return an OPA-backed or remote authorizer based on environment config.
+func NewAuthorizer(requiredGroup string) Authorizer {
+    return &LocalAuthorizer{requiredGroup: strings.TrimSpace(requiredGroup)}
+}

--- a/services/cluster/internal/authz/local_authorizer.go
+++ b/services/cluster/internal/authz/local_authorizer.go
@@ -1,0 +1,26 @@
+package authz
+
+import (
+    "context"
+)
+
+// LocalAuthorizer implements a minimal group-based check.
+type LocalAuthorizer struct{
+    requiredGroup string
+}
+
+// IsAllowed returns true when no required group is configured or when the
+// principal's groups contain the required group.
+func (l *LocalAuthorizer) IsAllowed(ctx context.Context, principal string, groups []string, resource string, verb string) (bool, string, error) {
+    if l.requiredGroup == "" {
+        return true, "", nil
+    }
+
+    for _, g := range groups {
+        if g == l.requiredGroup {
+            return true, "", nil
+        }
+    }
+
+    return false, "missing required group", nil
+}

--- a/services/cluster/internal/integration/probe.go
+++ b/services/cluster/internal/integration/probe.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -288,6 +289,23 @@ func ProbeWithConfig(ctx context.Context, cfg Config) Snapshot {
 		clusterVersion = clusterVersionResp.Items[0].Status.Desired.Version
 	}
 	reasons := degradedReasons(nodeResp, healthyNodes, unhealthyPods, availableDeployments, totalDeploymentReplicas, deploymentsErr, operatorIssues, appsErr, appIssues, nodesErr, podsErr, operatorsErr)
+
+	// Run SelfSubjectAccessReview checks to ensure the mounted service account
+	// has the expected read permissions for cluster resources used by the service.
+	ssrChecks := []ssrCheck{
+		{Verb: "get", Resource: "nodes", APIGroup: "", Namespace: ""},
+		{Verb: "list", Resource: "pods", APIGroup: "", Namespace: ""},
+		{Verb: "list", Resource: "namespaces", APIGroup: "", Namespace: ""},
+		{Verb: "list", Resource: "deployments", APIGroup: "apps", Namespace: ""},
+		{Verb: "get", Resource: "clusterversions", APIGroup: "config.openshift.io", Namespace: ""},
+		{Verb: "list", Resource: "clusteroperators", APIGroup: "config.openshift.io", Namespace: ""},
+		{Verb: "list", Resource: "applications", APIGroup: "argoproj.io", Namespace: "openshift-gitops"},
+	}
+
+	ssrReasons := runSelfSubjectAccessReviews(ctx, client, apiRoot, ssrChecks, tokenBytes)
+	if len(ssrReasons) > 0 {
+		reasons = append(reasons, ssrReasons...)
+	}
 	severity := "ok"
 	message := "OpenShift API is reachable."
 	if len(reasons) > 0 {
@@ -546,6 +564,110 @@ func degradedReasons(nodes nodeListPayload, readyNodes int, unhealthyPods int, a
 	} else if appIssues > 0 {
 		reasons = append(reasons, fmt.Sprintf("%d Argo CD application(s) are not healthy and synced.", appIssues))
 	}
+	return reasons
+}
+
+type ssrCheck struct {
+	Verb      string
+	Resource  string
+	APIGroup  string
+	Namespace string
+}
+
+type ssrSpec struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+	Spec       struct {
+		ResourceAttributes struct {
+			Namespace string `json:"namespace,omitempty"`
+			Verb      string `json:"verb,omitempty"`
+			Group     string `json:"group,omitempty"`
+			Resource  string `json:"resource,omitempty"`
+			Name      string `json:"name,omitempty"`
+		} `json:"resourceAttributes"`
+	} `json:"spec"`
+}
+
+type ssrResponse struct {
+	Status struct {
+		Allowed bool   `json:"allowed"`
+		Reason  string `json:"reason"`
+	} `json:"status"`
+}
+
+func postJSON[T any](ctx context.Context, client *http.Client, requestURL string, token []byte, body any) (T, int, error) {
+	var zero T
+
+	requestCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	buf := &bytes.Buffer{}
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return zero, 0, err
+	}
+
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodPost, requestURL, buf)
+	if err != nil {
+		return zero, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+string(token))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return zero, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return zero, resp.StatusCode, fmt.Errorf("upstream returned status %d", resp.StatusCode)
+	}
+
+	var payload T
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&payload); decodeErr != nil {
+		return zero, resp.StatusCode, decodeErr
+	}
+
+	return payload, resp.StatusCode, nil
+}
+
+func runSelfSubjectAccessReviews(ctx context.Context, client *http.Client, apiRoot string, checks []ssrCheck, token []byte) []string {
+	reasons := make([]string, 0)
+	endpoint := apiRoot + "/apis/authorization.k8s.io/v1/selfsubjectaccessreviews"
+
+	for _, c := range checks {
+		payload := ssrSpec{Kind: "SelfSubjectAccessReview", APIVersion: "authorization.k8s.io/v1"}
+		payload.Spec.ResourceAttributes.Verb = c.Verb
+		payload.Spec.ResourceAttributes.Resource = c.Resource
+		payload.Spec.ResourceAttributes.Group = c.APIGroup
+		if c.Namespace != "" {
+			payload.Spec.ResourceAttributes.Namespace = c.Namespace
+		}
+
+		_, status, err := postJSON[ssrResponse](ctx, client, endpoint, token, payload)
+		if err != nil {
+			reasons = append(reasons, fmt.Sprintf("SelfSubjectAccessReview failed for %s %s: %v", c.Verb, c.Resource, err))
+			continue
+		}
+		if status < 200 || status >= 400 {
+			reasons = append(reasons, fmt.Sprintf("SelfSubjectAccessReview returned %d for %s %s", status, c.Verb, c.Resource))
+			continue
+		}
+
+		// Note: postJSON already returns decode result into typed var, but we ignored it above.
+		// Do a second request to get the payload (simpler to reuse typed return here).
+		payloadResp, _, err := postJSON[ssrResponse](ctx, client, endpoint, token, payload)
+		if err != nil {
+			reasons = append(reasons, fmt.Sprintf("SelfSubjectAccessReview decode failed for %s %s: %v", c.Verb, c.Resource, err))
+			continue
+		}
+
+		if !payloadResp.Status.Allowed {
+			reasons = append(reasons, fmt.Sprintf("Service account missing permission: %s %s", c.Verb, c.Resource))
+		}
+	}
+
 	return reasons
 }
 

--- a/services/pfsense/Dockerfile
+++ b/services/pfsense/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.26-bookworm AS build
 
-WORKDIR /src
+COPY --from=pkg . /src/pkg
+
+WORKDIR /src/services/pfsense
 COPY go.mod ./
 COPY . .
 

--- a/services/pfsense/go.mod
+++ b/services/pfsense/go.mod
@@ -4,4 +4,6 @@ go 1.24.0
 
 require github.com/gosnmp/gosnmp v1.43.2
 
+require github.com/jlfowle/asterism/pkg/authz v0.0.0-00010101000000-000000000000 // indirect
+
 replace github.com/jlfowle/asterism/pkg/authz => ../../pkg/authz

--- a/services/pfsense/go.mod
+++ b/services/pfsense/go.mod
@@ -3,3 +3,5 @@ module github.com/jlfowle/asterism/services/pfsense
 go 1.24.0
 
 require github.com/gosnmp/gosnmp v1.43.2
+
+replace github.com/jlfowle/asterism/pkg/authz => ../../pkg/authz

--- a/services/pfsense/internal/api/auth.go
+++ b/services/pfsense/internal/api/auth.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
-	"slices"
 	"strings"
+
+	"github.com/jlfowle/asterism/pkg/authz"
+	"slices"
 )
 
 type contextKey string
@@ -15,6 +18,7 @@ const principalContextKey contextKey = "principal"
 type AuthMiddleware struct {
 	mode          string
 	requiredGroup string
+	authorizer    authz.Authorizer
 }
 
 func NewAuthMiddlewareFromEnv() AuthMiddleware {
@@ -28,6 +32,7 @@ func NewAuthMiddlewareFromEnv() AuthMiddleware {
 	return AuthMiddleware{
 		mode:          mode,
 		requiredGroup: requiredGroup,
+		authorizer:    authz.NewAuthorizer(requiredGroup),
 	}
 }
 
@@ -46,8 +51,13 @@ func (a AuthMiddleware) Protect(next http.Handler) http.Handler {
 
 		if a.requiredGroup != "" {
 			groups := a.readGroups(r)
-			if !slices.Contains(groups, a.requiredGroup) {
-				http.Error(w, "missing required group", http.StatusForbidden)
+			allowed, reason, err := a.authorizer.IsAllowed(r.Context(), principal, groups, r.URL.Path, r.Method)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("authorization error: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if !allowed {
+				http.Error(w, reason, http.StatusForbidden)
 				return
 			}
 		}

--- a/services/pfsense/internal/api/auth.go
+++ b/services/pfsense/internal/api/auth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/jlfowle/asterism/pkg/authz"
-	"slices"
+
 )
 
 type contextKey string

--- a/services/unifi/Dockerfile
+++ b/services/unifi/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.26-bookworm AS build
 
-WORKDIR /src
+COPY --from=pkg . /src/pkg
+
+WORKDIR /src/services/unifi
 COPY go.mod ./
 COPY . .
 

--- a/services/unifi/go.mod
+++ b/services/unifi/go.mod
@@ -1,3 +1,5 @@
 module github.com/jlfowle/asterism/services/unifi
 
 go 1.23
+
+replace github.com/jlfowle/asterism/pkg/authz => ../../pkg/authz

--- a/services/unifi/go.mod
+++ b/services/unifi/go.mod
@@ -2,4 +2,6 @@ module github.com/jlfowle/asterism/services/unifi
 
 go 1.23
 
+require github.com/jlfowle/asterism/pkg/authz v0.0.0-00010101000000-000000000000 // indirect
+
 replace github.com/jlfowle/asterism/pkg/authz => ../../pkg/authz

--- a/services/unifi/internal/api/auth.go
+++ b/services/unifi/internal/api/auth.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
-	"slices"
 	"strings"
+
+	"github.com/jlfowle/asterism/pkg/authz"
+	"slices"
 )
 
 type contextKey string
@@ -15,6 +18,7 @@ const principalContextKey contextKey = "principal"
 type AuthMiddleware struct {
 	mode          string
 	requiredGroup string
+	authorizer    authz.Authorizer
 }
 
 func NewAuthMiddlewareFromEnv() AuthMiddleware {
@@ -28,6 +32,7 @@ func NewAuthMiddlewareFromEnv() AuthMiddleware {
 	return AuthMiddleware{
 		mode:          mode,
 		requiredGroup: requiredGroup,
+		authorizer:    authz.NewAuthorizer(requiredGroup),
 	}
 }
 
@@ -46,8 +51,13 @@ func (a AuthMiddleware) Protect(next http.Handler) http.Handler {
 
 		if a.requiredGroup != "" {
 			groups := a.readGroups(r)
-			if !slices.Contains(groups, a.requiredGroup) {
-				http.Error(w, "missing required group", http.StatusForbidden)
+			allowed, reason, err := a.authorizer.IsAllowed(r.Context(), principal, groups, r.URL.Path, r.Method)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("authorization error: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if !allowed {
+				http.Error(w, reason, http.StatusForbidden)
 				return
 			}
 		}

--- a/services/unifi/internal/api/auth.go
+++ b/services/unifi/internal/api/auth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/jlfowle/asterism/pkg/authz"
-	"slices"
+
 )
 
 type contextKey string


### PR DESCRIPTION
This PR adds shared pkg/authz module (local and OPA authorizers), integrates the authorizer into services cluster, pfsense, and unifi, adds SelfSubjectAccessReview permission checks, and moves cluster-scoped RBAC to os-config.