### PR TITLE
test(authz): add unit tests for authz module and middleware

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,22 @@ jobs:
             services/${{ matrix.service.id }}/test-results
             services/${{ matrix.service.id }}/test-results/results.json
 
+  authz:
+    name: Verify pkg/authz
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: pkg/authz/go.mod
+
+      - name: Run tests
+        working-directory: pkg/authz
+        run: go test ./...
+
   containers:
     # The PR build is the source of truth for release publication; this job only packages artifacts.
     name: Build Container ${{ matrix.service.id }}

--- a/pkg/authz/authorizer_test.go
+++ b/pkg/authz/authorizer_test.go
@@ -1,0 +1,135 @@
+package authz
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewAuthorizer(t *testing.T) {
+	tests := []struct {
+		name          string
+		requiredGroup string
+		opaURL        string
+	}{
+		{
+			name:          "empty required group, no OPA",
+			requiredGroup: "",
+			opaURL:        "",
+		},
+		{
+			name:          "with required group and no OPA",
+			requiredGroup: "admin",
+			opaURL:        "",
+		},
+		{
+			name:          "with required group and OPA URL",
+			requiredGroup: "admin",
+			opaURL:        "http://localhost:8181",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.opaURL != "" {
+				t.Setenv("AUTHZ_OPA_URL", tt.opaURL)
+			} else {
+				t.Setenv("AUTHZ_OPA_URL", "")
+			}
+
+			auth := NewAuthorizer(tt.requiredGroup)
+			if auth == nil {
+				t.Fatal("expected non-nil authorizer")
+			}
+		})
+	}
+}
+
+func TestLocalAuthorizerAlwaysAllowsWhenNoRequiredGroup(t *testing.T) {
+	auth := &LocalAuthorizer{
+		requiredGroup: "",
+	}
+
+	allowed, reason, err := auth.IsAllowed(context.Background(), "user1", []string{}, "/api/v1/test", "GET")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Error("expected IsAllowed to return true when requiredGroup is empty")
+	}
+	if reason != "" {
+		t.Errorf("expected empty reason, got %q", reason)
+	}
+}
+
+func TestLocalAuthorizerWithMatch(t *testing.T) {
+	auth := &LocalAuthorizer{
+		requiredGroup: "admin",
+	}
+
+	allowed, reason, err := auth.IsAllowed(context.Background(), "user1", []string{"admin", "users"}, "/api/v1/test", "GET")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Error("expected IsAllowed to return true for matching group")
+	}
+	if reason != "" {
+		t.Errorf("expected empty reason for allowed access, got %q", reason)
+	}
+}
+
+func TestLocalAuthorizerWithoutMatch(t *testing.T) {
+	auth := &LocalAuthorizer{
+		requiredGroup: "admin",
+	}
+
+	allowed, reason, err := auth.IsAllowed(context.Background(), "user1", []string{"users", "viewers"}, "/api/v1/test", "GET")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("expected IsAllowed to return false for non-matching groups")
+	}
+	if reason == "" {
+		t.Error("expected non-empty denial reason")
+	}
+}
+
+func TestLocalAuthorizerWithEmptyGroups(t *testing.T) {
+	auth := &LocalAuthorizer{
+		requiredGroup: "admin",
+	}
+
+	allowed, reason, err := auth.IsAllowed(context.Background(), "user1", []string{}, "/api/v1/test", "GET")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("expected IsAllowed to return false for empty groups")
+	}
+	if reason == "" {
+		t.Error("expected non-empty denial reason")
+	}
+}
+
+func TestLocalAuthorizerWithNilGroups(t *testing.T) {
+	auth := &LocalAuthorizer{
+		requiredGroup: "admin",
+	}
+
+	allowed, reason, err := auth.IsAllowed(context.Background(), "user1", nil, "/api/v1/test", "GET")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Error("expected IsAllowed to return false for nil groups")
+	}
+	if reason == "" {
+		t.Error("expected non-empty denial reason")
+	}
+}

--- a/services/cluster/internal/api/auth_test.go
+++ b/services/cluster/internal/api/auth_test.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthMiddlewareDisabled(t *testing.T) {
+	middleware := AuthMiddleware{
+		mode:          "disabled",
+		requiredGroup: "",
+	}
+
+	handler := middleware.Protect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	}))
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddlewareEnforcedMissingPrincipal(t *testing.T) {
+	middleware := AuthMiddleware{
+		mode:          "enforced",
+		requiredGroup: "",
+	}
+
+	handler := middleware.Protect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddlewareEnforcedWithPrincipal(t *testing.T) {
+	middleware := AuthMiddleware{
+		mode:          "enforced",
+		requiredGroup: "",
+	}
+
+	handler := middleware.Protect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal := principalFromContext(r.Context())
+		if principal != "user@example.com" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("X-Forwarded-Email", "user@example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+}
+
+func TestAuthMiddlewareReadPrincipalPriority(t *testing.T) {
+	middleware := AuthMiddleware{
+		mode:          "enforced",
+		requiredGroup: "",
+	}
+
+	tests := []struct {
+		name      string
+		headers   map[string]string
+		expected  string
+	}{
+		{
+			name: "X-Asterism-Principal takes priority",
+			headers: map[string]string{
+				"X-Asterism-Principal": "principal@example.com",
+				"X-Forwarded-User":      "user@example.com",
+				"X-Forwarded-Email":     "email@example.com",
+			},
+			expected: "principal@example.com",
+		},
+		{
+			name: "X-Forwarded-User fallback",
+			headers: map[string]string{
+				"X-Forwarded-User":  "user@example.com",
+				"X-Forwarded-Email": "email@example.com",
+			},
+			expected: "user@example.com",
+		},
+		{
+			name: "X-Forwarded-Email fallback",
+			headers: map[string]string{
+				"X-Forwarded-Email": "email@example.com",
+			},
+			expected: "email@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := middleware.Protect(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				principal := principalFromContext(r.Context())
+				if principal != tt.expected {
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(principal))
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest("GET", "/api/test", nil)
+			for key, val := range tt.headers {
+				req.Header.Set(key, val)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestAuthMiddlewareReadGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected []string
+	}{
+		{
+			name:     "single group",
+			header:   "admin",
+			expected: []string{"admin"},
+		},
+		{
+			name:     "multiple groups",
+			header:   "admin,users,viewers",
+			expected: []string{"admin", "users", "viewers"},
+		},
+		{
+			name:     "groups with whitespace",
+			header:   "admin, users , viewers",
+			expected: []string{"admin", "users", "viewers"},
+		},
+		{
+			name:     "empty header",
+			header:   "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a custom middleware for testing group extraction
+			m := &AuthMiddleware{mode: "disabled"}
+
+			req := httptest.NewRequest("GET", "/api/test", nil)
+			if tt.header != "" {
+				req.Header.Set("X-Asterism-Groups", tt.header)
+			}
+
+			groups := m.readGroups(req)
+
+			if len(groups) != len(tt.expected) {
+				t.Errorf("expected %d groups, got %d: %v", len(tt.expected), len(groups), groups)
+				return
+			}
+
+			for i, g := range groups {
+				if g != tt.expected[i] {
+					t.Errorf("group %d: expected %q, got %q", i, tt.expected[i], g)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the pkg/authz module and auth middleware integration in the cluster service.

Tests include:
- Authorizer factory behavior
- LocalAuthorizer group matching logic
- AuthMiddleware access control and principal extraction
- Group header parsing