### PR TITLE
fix(docker): correct pkg context copy path for go.mod replace directives

### DIFF
--- a/services/cluster/Dockerfile
+++ b/services/cluster/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.26-bookworm AS build
 
-COPY --from=pkg . /src/pkg
+WORKDIR /src
+
+# Copy the pkg directory from the named build context
+COPY --from=pkg . ./pkg
 
 WORKDIR /src/services/cluster
 COPY go.mod ./

--- a/services/pfsense/Dockerfile
+++ b/services/pfsense/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.26-bookworm AS build
 
-COPY --from=pkg . /src/pkg
+WORKDIR /src
+
+# Copy the pkg directory from the named build context
+COPY --from=pkg . ./pkg
 
 WORKDIR /src/services/pfsense
 COPY go.mod ./

--- a/services/unifi/Dockerfile
+++ b/services/unifi/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.26-bookworm AS build
 
-COPY --from=pkg . /src/pkg
+WORKDIR /src
+
+# Copy the pkg directory from the named build context
+COPY --from=pkg . ./pkg
 
 WORKDIR /src/services/unifi
 COPY go.mod ./


### PR DESCRIPTION
This follow-up PR cherry-picks the Dockerfile context fix from the earlier authz-package line onto current `main` as a fresh branch.

What changed:
- Updates the `services/cluster`, `services/pfsense`, and `services/unifi` Dockerfiles so the build context includes `pkg/authz` for `go.mod` replace directives.

Why:
- The previous authz packaging work landed, but the service Docker builds still needed the shared package copied into context when building from the service directories.

Validation:
- `git diff --check origin/main..HEAD`

This branch is intentionally limited to the new Dockerfile fix and does not include the older stale branch history.