### PR TITLE
feat(release): render deploy asset from release manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -218,13 +218,21 @@ jobs:
           digest="$(sha256sum release-manifest.json | awk '{print $1}')"
           echo "sha256=${digest}" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout reviewed merge commit
+        if: steps.release_state.outputs.release_exists != 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.MERGE_COMMIT_SHA }}
+          path: source-tree
+          fetch-depth: 0
+
       - name: Render release deployment asset
         if: steps.release_state.outputs.release_exists != 'true'
         env:
           RELEASE_MANIFEST_SHA256: ${{ steps.release_manifest.outputs.sha256 }}
         run: |
           scripts/release/render-release-deploy.sh \
-            --source-dir deploy \
+            --source-dir source-tree/deploy \
             --release-manifest release-manifest.json \
             --manifest-sha256 "$RELEASE_MANIFEST_SHA256" \
             --output artifacts/release/asterism-deploy.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,17 +174,6 @@ jobs:
             --dest artifacts/release-source \
             --expected-services-json "$EXPECTED_SERVICES_JSON"
 
-      - name: Download rendered manifests
-        if: steps.release_state.outputs.release_exists != 'true'
-        uses: actions/download-artifact@v8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          run-id: ${{ steps.source_run.outputs.run_id }}
-          pattern: rendered-*
-          merge-multiple: true
-          path: artifacts/rendered
-
       - name: Install Cosign
         if: steps.release_state.outputs.release_exists != 'true'
         uses: sigstore/cosign-installer@v4.1.1
@@ -229,6 +218,17 @@ jobs:
           digest="$(sha256sum release-manifest.json | awk '{print $1}')"
           echo "sha256=${digest}" >> "$GITHUB_OUTPUT"
 
+      - name: Render release deployment asset
+        if: steps.release_state.outputs.release_exists != 'true'
+        env:
+          RELEASE_MANIFEST_SHA256: ${{ steps.release_manifest.outputs.sha256 }}
+        run: |
+          scripts/release/render-release-deploy.sh \
+            --source-dir deploy \
+            --release-manifest release-manifest.json \
+            --manifest-sha256 "$RELEASE_MANIFEST_SHA256" \
+            --output artifacts/release/asterism-deploy.yaml
+
       - name: Upload release assets
         if: steps.release_state.outputs.release_exists != 'true'
         uses: softprops/action-gh-release@v3
@@ -240,7 +240,7 @@ jobs:
           generate_release_notes: true
           files: |
             release-manifest.json
-            artifacts/rendered/*.yaml
+            artifacts/release/asterism-deploy.yaml
             artifacts/release-source/sbom-*.spdx.json
             artifacts/release/image-metadata-*.json
 
@@ -290,9 +290,7 @@ jobs:
           scripts/release/promote-os-config.py \
             --repo-dir os-config \
             --version "${{ steps.release_state.outputs.version }}" \
-            --source-repo "${{ github.repository }}" \
-            --commit "${{ env.MERGE_COMMIT_SHA }}" \
-            --manifest-sha256 "${{ steps.release_manifest.outputs.sha256 }}"
+            --source-repo "${{ github.repository }}"
 
       - name: Validate promoted GitOps overlay
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,11 +60,11 @@ GitHub Actions pipeline includes:
 - PR-built container archives, release-time GHCR push for immutable `vX.Y.Z` and moving `latest` tags,
 - keyless image signing and SBOM generation,
 - release automation in the GitHub Actions `release` environment with environment-scoped release credentials,
-- GitHub Release assets including rendered Kustomize manifests and machine-readable release metadata.
+- GitHub Release assets including a deployable `asterism-deploy.yaml` manifest and machine-readable release metadata.
 
 ## GitOps Flow
 1. CI validates pull requests and uploads release-source image archives, SBOMs, metadata, and rendered manifests.
-2. Release reuses the successful PR artifacts for the exact reviewed head SHA, publishes immutable and `latest` image tags, signs digests, and creates the release manifest.
-3. Release automation commits the new Asterism release ref and rollout annotations to the separate GitOps repository.
+2. Release reuses the successful PR artifacts for the exact reviewed head SHA, publishes immutable and `latest` image tags, signs digests, creates the release manifest, and renders `asterism-deploy.yaml` with `vX.Y.Z@sha256:...` image refs.
+3. Release automation commits the GitOps pointer to the GitHub release asset in the separate deployment repository.
 4. OpenShift GitOps reconciles the deployed environment from the GitOps repository.
 5. Release verification polls Argo CD until the application is synced, healthy, rolled out, and running the expected image digests.

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -53,8 +53,8 @@ These standards apply to both human contributors and AI agents working in Asteri
 ## 7. Environment Strategy
 - There is only one deployed environment.
 - That environment is promoted from the `main` branch only.
-- Deployment consumes `latest` tags produced from successful `main` builds.
-- Even with a `latest` deployment strategy, releases should preserve traceability through versioning, digests, provenance, and SBOM metadata.
+- Successful `main` builds continue to publish `latest` tags for compatibility and rollback simplicity.
+- Release-published deployment manifests must pin images as `version@sha256:...` so the deployed payload is traceable and immutable.
 
 ## 8. CI Expectations
 - CI is implemented in GitHub Actions.
@@ -69,7 +69,7 @@ These standards apply to both human contributors and AI agents working in Asteri
 - Build outputs that become part of the shipped release should be produced once from the reviewed PR commit and reused for release publication.
 - Auxiliary metadata may be assembled or regenerated at release time when that simplifies the workflow, provided the release still points back to the reviewed commit and the PR-built payload.
 - Container releases must publish both immutable release tags and the moving `latest` deployment tags, record pushed digests, sign immutable digests, and preserve SBOM metadata.
-- Release artifacts should be machine-readable where practical to support audit, promotion, and GitOps automation.
+- Release artifacts should be machine-readable where practical to support audit, promotion, and GitOps automation; when a deployment manifest is published as a release asset, it should pin images as `version@sha256:...`.
 - GitOps promotion should update the separate deployment repository only after release images and release metadata are complete, and post-promotion verification should confirm Argo CD sync, health, rollout, and running image digests.
 
 ## 10. Repository Working Agreements

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -2,15 +2,15 @@
 
 Each GitHub release includes:
 - `release-manifest.json`
-- `*.yaml` Kustomize rendered manifests
+- `asterism-deploy.yaml`
 - `sbom-*.spdx.json`
 - `image-metadata-*.json`
 
-The shipped image bytes and rendered manifests are reused from the reviewed PR build. Release publication loads those PR-built image archives, pushes immutable `vX.Y.Z` tags and the moving `latest` deployment tags, signs each immutable image digest, and fails if any expected service is missing an image archive, SBOM, digest, or metadata entry.
+The shipped image bytes are reused from the reviewed PR build. Release publication loads those PR-built image archives, pushes immutable `vX.Y.Z` tags and the moving `latest` deployment tags, signs each immutable image digest, and then renders `asterism-deploy.yaml` with image references pinned to `vX.Y.Z@sha256:...`. Release publication fails if any expected service is missing an image archive, SBOM, digest, metadata entry, or deployable manifest.
 
 Release reruns are idempotent for a merged commit that already has a published release manifest: the workflow reuses that manifest and version instead of minting a second release.
 
-After image publication succeeds, release automation commits the matching Asterism release ref to the separate GitOps repository and adds pod-template annotations that force a rollout while deployments continue to reference `:latest`. Argo CD auto-syncs from the GitOps change via its webhook path, and verification polls until the app is synced and healthy and the running pod image IDs match the release manifest digests.
+After image publication succeeds, release automation commits an `os-config` Kustomize pointer to the GitHub release asset, and that asset already contains the pod-template annotations and digest-pinned image references needed for rollout. Argo CD auto-syncs from the GitOps change via its webhook path, and verification polls until the app is synced and healthy and the running pod image IDs match the release manifest digests.
 
 The release workflow runs in the GitHub Actions `release` environment. Store release-only credentials there so they are only exposed to the release job.
 
@@ -37,6 +37,15 @@ The release workflow runs in the GitHub Actions `release` environment. Store rel
 ```
 
 Consumers (GitOps automation, audit jobs, or promotion tooling) can parse this file without scraping release notes.
+
+## asterism-deploy.yaml
+This release asset is the deployable manifest for `app-asterism`. It is rendered from the repo's `deploy/` tree after image publication and contains:
+- `namespace: app-asterism`
+- `app: asterism` labels
+- release annotations for version, commit, and manifest digest
+- image references in `ghcr.io/...:vX.Y.Z@sha256:...` form
+
+The GitOps repository should point its Asterism overlay at this asset rather than at the source `deploy/` tree.
 
 ## Required Release Configuration
 - GitHub App credentials used by the release workflow to update the private GitOps repository (`os-config`):

--- a/scripts/release/promote-os-config.py
+++ b/scripts/release/promote-os-config.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import re
 from pathlib import Path
 
 
@@ -12,48 +11,17 @@ def parse_args():
     parser.add_argument("--repo-dir", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--source-repo", required=True)
-    parser.add_argument("--commit", required=True)
-    parser.add_argument("--manifest-sha256", required=True)
+    parser.add_argument("--asset-name", default="asterism-deploy.yaml")
     return parser.parse_args()
 
 
-def read_namespace(path):
-    if not path.exists():
-        return "app-asterism"
-
-    match = re.search(r"(?m)^namespace:\s*([^\s#]+)", path.read_text(encoding="utf-8"))
-    return match.group(1) if match else "app-asterism"
-
-
-def build_kustomization(namespace, source_repo, version, commit, manifest_sha256):
-    resource_ref = f"github.com/{source_repo}//deploy?ref={version}"
+def build_kustomization(source_repo, version, asset_name):
+    asset_url = f"https://github.com/{source_repo}/releases/download/{version}/{asset_name}"
     return f"""apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: {namespace}
 
 resources:
-  - {resource_ref}
-
-labels:
-  - pairs:
-      app: asterism
-
-patches:
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-      labelSelector: app.kubernetes.io/part-of=asterism
-    patch: |-
-      - op: add
-        path: /spec/template/metadata/annotations/asterism.dev~1release-version
-        value: "{version}"
-      - op: add
-        path: /spec/template/metadata/annotations/asterism.dev~1release-commit
-        value: "{commit}"
-      - op: add
-        path: /spec/template/metadata/annotations/asterism.dev~1release-manifest-sha256
-        value: "{manifest_sha256}"
+  - {asset_url}
 """
 
 
@@ -64,13 +32,10 @@ def main():
     if not overlay_path.parent.is_dir():
         raise SystemExit(f"Asterism overlay directory does not exist: {overlay_path.parent}")
 
-    namespace = read_namespace(overlay_path)
     rendered = build_kustomization(
-        namespace=namespace,
         source_repo=args.source_repo,
         version=args.version,
-        commit=args.commit,
-        manifest_sha256=args.manifest_sha256,
+        asset_name=args.asset_name,
     )
 
     if overlay_path.exists() and overlay_path.read_text(encoding="utf-8") == rendered:

--- a/scripts/release/render-release-deploy.sh
+++ b/scripts/release/render-release-deploy.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: render-release-deploy.sh --source-dir DIR --release-manifest FILE --manifest-sha256 SHA --output FILE
+
+Renders the deployable Asterism manifest for a release by overlaying the
+published image digests and release metadata onto the repo's deploy tree.
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_DIR="${SOURCE_DIR:-deploy}"
+RELEASE_MANIFEST=""
+MANIFEST_SHA256=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-dir)
+      SOURCE_DIR="$2"
+      shift 2
+      ;;
+    --release-manifest)
+      RELEASE_MANIFEST="$2"
+      shift 2
+      ;;
+    --manifest-sha256)
+      MANIFEST_SHA256="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$RELEASE_MANIFEST" || -z "$MANIFEST_SHA256" || -z "$OUTPUT" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "$RELEASE_MANIFEST" ]]; then
+  echo "Release manifest does not exist: $RELEASE_MANIFEST" >&2
+  exit 1
+fi
+
+if [[ "$SOURCE_DIR" = /* ]]; then
+  SOURCE_PATH="$SOURCE_DIR"
+else
+  SOURCE_PATH="$REPO_ROOT/$SOURCE_DIR"
+fi
+if [[ ! -d "$SOURCE_PATH" ]]; then
+  echo "Release source directory does not exist: $SOURCE_PATH" >&2
+  exit 1
+fi
+
+version="$(jq -r '.version // empty' "$RELEASE_MANIFEST")"
+commit="$(jq -r '.commit // empty' "$RELEASE_MANIFEST")"
+services_json="$(jq -c '.services // []' "$RELEASE_MANIFEST")"
+
+if [[ -z "$version" || -z "$commit" ]]; then
+  echo "Release manifest is missing version or commit." >&2
+  exit 1
+fi
+
+if ! jq -e 'type == "array" and length > 0 and all(.[]; (.service | type == "string" and length > 0) and (.image | type == "string" and length > 0) and (.digest | test("^sha256:[0-9a-fA-F]{64}$")) and (.version | type == "string" and length > 0))' <<< "$services_json" > /dev/null; then
+  echo "Release manifest services must include service, image, digest, and version fields." >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+ln -s "$SOURCE_PATH" "$tmp_dir/deploy"
+
+images_block="$(
+  jq -r '
+    .[] |
+    "  - name: \(.image)\n" +
+    "    newName: \(.image)\n" +
+    "    newTag: \(.version)\n" +
+    "    digest: \(.digest)"
+  ' <<< "$services_json"
+)"
+
+mkdir -p "$(dirname "$OUTPUT")"
+cat > "$tmp_dir/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: app-asterism
+
+resources:
+  - deploy
+
+labels:
+  - pairs:
+      app: asterism
+
+images:
+$images_block
+
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      labelSelector: app.kubernetes.io/part-of=asterism
+    patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations/asterism.dev~1release-version
+        value: "$version"
+      - op: add
+        path: /spec/template/metadata/annotations/asterism.dev~1release-commit
+        value: "$commit"
+      - op: add
+        path: /spec/template/metadata/annotations/asterism.dev~1release-manifest-sha256
+        value: "$MANIFEST_SHA256"
+EOF
+
+kustomize build --load-restrictor=LoadRestrictionsNone "$tmp_dir" > "$OUTPUT"
+
+echo "Wrote release deployment manifest to $OUTPUT."

--- a/scripts/release/test-release-automation.sh
+++ b/scripts/release/test-release-automation.sh
@@ -59,6 +59,76 @@ manifest="$TMP_DIR/release-manifest.json"
 jq -e '.services | length == 1' "$manifest" > /dev/null
 jq -e '.services[0].digest == "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"' "$manifest" > /dev/null
 
+render_repo="$TMP_DIR/render-repo"
+mkdir -p "$render_repo/deploy/base"
+cat > "$render_repo/deploy/base/deployment.yaml" <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pfsense
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pfsense
+      app.kubernetes.io/part-of: asterism
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/name: pfsense
+        app.kubernetes.io/part-of: asterism
+    spec:
+      containers:
+        - name: pfsense
+          image: pfsense
+EOF
+cat > "$render_repo/deploy/base/service.yaml" <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: pfsense
+spec:
+  selector:
+    app.kubernetes.io/name: pfsense
+    app.kubernetes.io/part-of: asterism
+EOF
+cat > "$render_repo/deploy/kustomization.yaml" <<'EOF'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: asterism
+resources:
+  - ./base/deployment.yaml
+  - ./base/service.yaml
+images:
+  - name: pfsense
+    newName: ghcr.io/jlfowle/asterism-pfsense
+    newTag: latest
+labels:
+  - pairs:
+      app.kubernetes.io/name: pfsense
+      app.kubernetes.io/part-of: asterism
+    includeSelectors: true
+    includeTemplates: true
+EOF
+
+render_output="$TMP_DIR/asterism-deploy.yaml"
+"$SCRIPT_DIR/render-release-deploy.sh" \
+  --source-dir "$render_repo/deploy" \
+  --release-manifest "$manifest" \
+  --manifest-sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --output "$render_output"
+
+grep -q 'ghcr.io/jlfowle/asterism-pfsense:v1.2.3@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' "$render_output"
+grep -q 'asterism.dev/release-version: v1.2.3' "$render_output"
+grep -q 'asterism.dev/release-commit: abcdef0123456789' "$render_output"
+grep -q 'asterism.dev/release-manifest-sha256:' "$render_output"
+grep -q 'namespace: app-asterism' "$render_output"
+if grep -q ':latest' "$render_output"; then
+  echo "render-release-deploy.sh unexpectedly left a latest tag in the release manifest." >&2
+  exit 1
+fi
+
 if "$SCRIPT_DIR/build-release-manifest.sh" --release-dir "$TMP_DIR" --output "$TMP_DIR/empty.json" --version v1.2.3 --commit abc --expected-services-json "$expected" >/dev/null 2>&1; then
   echo "build-release-manifest.sh unexpectedly succeeded without image metadata." >&2
   exit 1
@@ -126,21 +196,19 @@ EOF
 "$SCRIPT_DIR/promote-os-config.py" \
   --repo-dir "$cd_repo" \
   --version v1.2.3 \
-  --source-repo jlfowle/asterism \
-  --commit abcdef0123456789 \
-  --manifest-sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  --source-repo jlfowle/asterism
 
-grep -q 'github.com/jlfowle/asterism//deploy?ref=v1.2.3' "$cd_repo/app/asterism/kustomization.yaml"
-grep -q 'asterism.dev~1release-version' "$cd_repo/app/asterism/kustomization.yaml"
-grep -q '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' "$cd_repo/app/asterism/kustomization.yaml"
+grep -q 'https://github.com/jlfowle/asterism/releases/download/v1.2.3/asterism-deploy.yaml' "$cd_repo/app/asterism/kustomization.yaml"
+if grep -q 'release-version' "$cd_repo/app/asterism/kustomization.yaml"; then
+  echo "promote-os-config.py should not inject deployment annotations." >&2
+  exit 1
+fi
 
 before_sha="$(sha256sum "$cd_repo/app/asterism/kustomization.yaml" | awk '{print $1}')"
 "$SCRIPT_DIR/promote-os-config.py" \
   --repo-dir "$cd_repo" \
   --version v1.2.3 \
-  --source-repo jlfowle/asterism \
-  --commit abcdef0123456789 \
-  --manifest-sha256 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  --source-repo jlfowle/asterism
 after_sha="$(sha256sum "$cd_repo/app/asterism/kustomization.yaml" | awk '{print $1}')"
 
 if [[ "$before_sha" != "$after_sha" ]]; then


### PR DESCRIPTION
## Summary
- Render and publish `asterism-deploy.yaml` as the release deploy artifact.
- Point `os-config` at the GitHub release asset URL instead of the source `deploy/` tree.
- Pin deployment images to `version@sha256:...` in the release asset while keeping `:latest` publication for compatibility.

## Validation
- `scripts/release/test-release-automation.sh`
- `kustomize build deploy`
- `git diff --check`
- `bash -n` on touched release scripts
- live render of `deploy/` through `scripts/release/render-release-deploy.sh`