### PR TITLE
docs: align auth standards and verification

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ This document summarizes the current platform direction. Repository-wide behavio
 - `services/<service>/deploy`: Kubernetes deployment manifests (kustomization.yaml entrypoint + base/ directory).
 - `deploy/kustomization.yaml`: Auto-generated consolidated kustomization (auto-discovered via `scripts/update-deploy.sh`).
 - `deploy/platform/routing`: Gateway API HTTPRoutes for the single Asterism public entry point.
-- `deploy/platform/security`: Service Mesh mTLS and Cognito OIDC policy scaffolding.
+- `deploy/platform/security`: Service Mesh mTLS, edge auth proxy, and OPA authorization policy scaffolding.
 
 ## API And Event Contracts
 Each service keeps:
@@ -44,13 +44,14 @@ This keeps contracts with implementation ownership and supports separate lifecyc
 - Service output is returned in `/api/v1/status.integration`, mirrored by `/api/v1/summary`, and includes severity, degraded reasons, recommended actions, authoritative links, and disabled guided action contracts.
 
 ## Security Model
-- External user authentication is delegated through Cognito OIDC.
-- External user authorization is enforced in application code.
+- External user authentication is delegated through the OpenShift OAuth edge proxy.
+- Polaris sits behind that edge proxy and does not own browser bearer-token handling directly.
+- External user authorization is enforced in application code and backed by OPA where the service has a shared policy decision endpoint.
+- Service endpoints consume verified identity context from the edge proxy and should only trust proxy-provided principal headers.
 - Internal service-to-service authentication and authorization are delegated to the service mesh using mTLS and mesh policy.
 - Secret material is sourced from AWS Secrets Manager through External Secrets Operator.
-- Protected service endpoints (`/api/v1/status`) require identity context by default (`AUTH_MODE=enforced`) and read forwarded principal/group headers (`X-Asterism-Principal`, `X-Asterism-Groups`).
-- Polaris supports runtime-configured Cognito OIDC sign-in with Authorization Code + PKCE and sends bearer tokens to protected service APIs when configured.
-- External traffic enters through `https://asterism.apps.os.fowler.house/` and is routed by Service Mesh Gateway API resources rather than direct per-service OpenShift Routes.
+- Protected service endpoints (`/api/v1/status`) require identity context by default (`AUTH_MODE=enforced`) and can call a shared OPA decision service via `AUTHZ_OPA_URL`.
+- External traffic enters through `https://asterism.apps.os.fowler.house/`, lands on the OpenShift OAuth front door, and then reaches Polaris and downstream service APIs through the mesh ingress path rather than direct per-service OpenShift Routes.
 
 ## CI/CD And Supply Chain
 GitHub Actions pipeline includes:

--- a/docs/authn-authz-rollout-verification.md
+++ b/docs/authn-authz-rollout-verification.md
@@ -1,0 +1,37 @@
+# Authn/Authz Rollout Verification
+
+This checklist is the working verification plan for the OpenShift OAuth edge proxy and OPA-backed service authorization rollout.
+
+## Pre-merge Checks
+
+- [ ] `make test`
+- [ ] `kustomize build deploy`
+- [ ] PR checks are green: `Lint PR`, `CI`, and `PR Merge Readiness`
+- [ ] The Polaris build still emits `microfrontends.json`
+
+## Public Edge Checks
+
+- [ ] Unauthenticated `GET /` redirects into OpenShift login
+- [ ] Authenticated `GET /` renders the Polaris shell
+- [ ] Sign-out returns through the OpenShift OAuth logout path
+- [ ] Public requests use `GET`, not `HEAD`, when checking the routed edge behavior
+
+## Service Authorization Checks
+
+- [ ] `GET /api/services/{service}/api/v1/status` succeeds for an authenticated principal
+- [ ] `GET /api/services/{service}/api/v1/summary` succeeds for an authenticated principal
+- [ ] `GET /api/services/{service}/api/v1/actions` stays read-only and returns disabled contracts
+- [ ] Spoofed `X-Asterism-Principal` headers are ignored
+- [ ] The service still accepts proxy-provided `X-Forwarded-User` and `X-Forwarded-Email` headers
+- [ ] When `AUTHZ_OPA_URL` is set, OPA denial returns `403`
+
+## GitOps And Release Checks
+
+- [ ] The GitOps repository reports the app as Synced and Healthy
+- [ ] The running pod image digests match the release manifest
+- [ ] The release asset still renders with pod-template annotations and digest-pinned image references
+
+## Notes
+
+- Keep the tracker in `/workspace/docs/asterism-authn-authz-stabilization-tracker.md` up to date as each branch lands.
+- Check the current and previous PRs for comments before starting the next branch.

--- a/docs/deploy-standards.md
+++ b/docs/deploy-standards.md
@@ -34,9 +34,11 @@ deploy/
 ├── kustomization.yaml              # AUTO-GENERATED; references all services and platform policies
 ├── platform/
 │   ├── routing/                    # Gateway API HTTPRoutes for public app routing
-│   └── security/                   # Cross-cutting Istio and OIDC policies
+│   └── security/                   # Cross-cutting Istio, OPA, and edge-auth policies
 │       ├── authorization-policy.yaml
-│       ├── request-authentication.yaml
+│       ├── opa-configmap.yaml
+│       ├── opa-deployment.yaml
+│       ├── opa-service.yaml
 │       ├── peer-authentication.yaml
 │       └── kustomization.yaml
 └── [other platform-level resources]
@@ -46,6 +48,7 @@ deploy/
 - `deploy/kustomization.yaml` is **auto-generated** by `scripts/update-deploy.sh`; do not edit it manually
 - `deploy/platform/routing/` contains Asterism's Gateway API `HTTPRoute` resources for the single public entry point
 - `deploy/platform/security/` contains infrastructure cross-cutting concerns, not service-owned
+- The public host is fronted by the Polaris auth proxy deployment in `services/polaris/deploy/base/auth-proxy-*`; it owns the OpenShift OAuth edge and forwards trusted user identity into Polaris and downstream APIs
 - The consolidation is a simple aggregation via kustomize resource references
 
 ## Service Deploy Manifest Requirements
@@ -63,6 +66,7 @@ runtime secret dependency.
 - Required environment variables:
   - `PORT=8080`
   - `AUTH_MODE=enforced`
+  - `AUTHZ_OPA_URL=http://asterism-opa:8181` when the service uses shared OPA-backed authorization
   - Service-specific environment variables (e.g., `CLUSTER_API_URL` for services that need it)
 - Security context: non-root user, read-only root filesystem, no Linux capabilities
 - Istio sidecar injection enabled (via label `sidecar.istio.io/inject: "true"`)
@@ -283,3 +287,4 @@ If `git diff` shows no changes, the discovery is up to date. If changes exist, c
 - [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)
 - [ExternalSecrets Operator](https://external-secrets.io/)
 - [Istio Injection](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/)
+- [Authn/Authz rollout verification](./authn-authz-rollout-verification.md)

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -26,9 +26,10 @@ These standards apply to both human contributors and AI agents working in Asteri
 ## 4. Authentication And Authorization
 
 ### External traffic
-- User authentication is delegated through OpenID Connect with AWS Cognito.
-- User authorization is handled in the application.
-- Service endpoints should consume verified identity context and enforce authorization decisions in service code where user-facing access is concerned.
+- User authentication is delegated through the OpenShift OAuth edge proxy.
+- User authorization is handled in the application and may be backed by OPA for shared policy decisions.
+- Service endpoints should consume verified identity context from the proxy and enforce authorization decisions in service code where user-facing access is concerned.
+- Only trust proxy-provided identity headers such as `X-Forwarded-User` and `X-Forwarded-Email`; do not trust client-supplied principal headers.
 
 ### Internal traffic
 - Service-to-service authentication and authorization are delegated to the service mesh.
@@ -48,6 +49,7 @@ These standards apply to both human contributors and AI agents working in Asteri
 - The Argo CD `Application` definitions live in a separate repository and are intentionally not managed here.
 - Manifests in this repository should remain GitOps-friendly and declarative.
 - Prefer OpenShift-native constructs when choosing between equivalent deployment options.
+- The public edge auth front door lives with Polaris in `services/polaris/deploy/base/auth-proxy-*` and should route through the shared mesh ingress rather than exposing direct per-service Routes.
 - Do not expose Asterism workloads with direct per-service OpenShift Routes; use the shared mesh ingress and Gateway API route model.
 
 ## 7. Environment Strategy


### PR DESCRIPTION
Update the durable architecture, engineering, and deploy standards to match the OpenShift OAuth edge proxy and OPA-backed service authorization rollout, and add a dedicated rollout verification checklist for future PRs.\n\nValidation: docs-only change; reviewed the updated manifests, standards, and verification checklist.