### PR TITLE
fix: restore release render annotations

### DIFF
--- a/docs/deploy-standards.md
+++ b/docs/deploy-standards.md
@@ -68,6 +68,7 @@ runtime secret dependency.
   - `AUTH_MODE=enforced`
   - `AUTHZ_OPA_URL=http://asterism-opa:8181` when the service uses shared OPA-backed authorization
   - Service-specific environment variables (e.g., `CLUSTER_API_URL` for services that need it)
+- The pod template metadata must include an `annotations` map, even when it starts empty, so release metadata overlays can inject immutable release annotations without failing
 - Security context: non-root user, read-only root filesystem, no Linux capabilities
 - Istio sidecar injection enabled (via label `sidecar.istio.io/inject: "true"`)
 

--- a/services/polaris/deploy/base/auth-proxy-deployment.yaml
+++ b/services/polaris/deploy/base/auth-proxy-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: auth-proxy
+      annotations: {}
     spec:
       serviceAccountName: asterism-auth-proxy
       securityContext:


### PR DESCRIPTION
## Summary\n- add the missing pod-template annotations map so the release renderer can inject immutable release metadata\n- document the deployment template requirement in deploy standards\n- track the release workflow fix alongside the earlier authn/authz rollout items\n\n## Validation\n- scripts/release/render-release-deploy.sh against the live deploy tree with a dummy release manifest\n- scripts/release/test-release-automation.sh\n- kustomize build deploy\n\n## Notes\nThis resolves the release job failure that was aborting on /spec/template/metadata/annotations/asterism.dev~1release-version while rendering the auth-proxy Deployment.