### PR TITLE
fix: disable auth proxy https listener

### DIFF
--- a/docs/deploy-standards.md
+++ b/docs/deploy-standards.md
@@ -49,6 +49,7 @@ deploy/
 - `deploy/platform/routing/` contains Asterism's Gateway API `HTTPRoute` resources for the single public entry point
 - `deploy/platform/security/` contains infrastructure cross-cutting concerns, not service-owned
 - The public host is fronted by the Polaris auth proxy deployment in `services/polaris/deploy/base/auth-proxy-*`; it owns the OpenShift OAuth edge and forwards trusted user identity into Polaris and downstream APIs
+- When the auth proxy runs behind the OpenShift edge route without a mounted serving cert, it must set `--https-address=` so oauth-proxy stays HTTP-only and does not crash while loading TLS config
 - The consolidation is a simple aggregation via kustomize resource references
 
 ## Service Deploy Manifest Requirements

--- a/services/polaris/deploy/base/auth-proxy-deployment.yaml
+++ b/services/polaris/deploy/base/auth-proxy-deployment.yaml
@@ -34,6 +34,7 @@ spec:
                   fieldPath: metadata.namespace
           args:
             - --http-address=0.0.0.0:4180
+            - --https-address=
             - --upstream=http://asterism-internal.apps.os.fowler.house/
             - --openshift-service-account=asterism-auth-proxy
             - '--openshift-sar={"namespace":"$(POD_NAMESPACE)","resource":"services","resourceName":"asterism-auth-proxy","verb":"get"}'


### PR DESCRIPTION
## Summary\n- keep the OpenShift oauth-proxy auth edge HTTP-only behind the cluster route\n- prevent the auth proxy pod from crash looping while loading a missing serving cert\n- document the runtime expectation in deploy standards\n\n## Validation\n- kustomize build services/polaris/deploy\n- kustomize build deploy\n\n## Observed failure\nThe live public host was returning 503 because the auth-proxy pod was crash-looping with: "FATAL: loading tls config (, ) failed - missing filename for serving cert".