### PR TITLE
fix(deploy): provision auth proxy cookie secret

### DIFF
--- a/docs/deploy-standards.md
+++ b/docs/deploy-standards.md
@@ -91,6 +91,7 @@ runtime secret dependency.
 
 Current service secret shapes:
 
+- `/asterism/auth-proxy`: `cookieSecret`
 - `/asterism/unifi`: `apiBaseUrl`, `apiToken`, optional `siteId`, optional `consoleUrl`
 - `/asterism/pfsense`: `snmpHost`, `snmpCommunity`, optional `snmpPort`, optional `consoleUrl`, optional `expectedUpInterfaces`
 

--- a/services/polaris/deploy/base/externalsecret.yaml
+++ b/services/polaris/deploy/base/externalsecret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: asterism-auth-proxy-cookie
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: aws-secretsmanager
+  target:
+    name: asterism-auth-proxy-cookie
+    creationPolicy: Owner
+  data:
+    - secretKey: cookie-secret
+      remoteRef:
+        key: /asterism/auth-proxy
+        property: cookieSecret

--- a/services/polaris/deploy/kustomization.yaml
+++ b/services/polaris/deploy/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./base/auth-proxy-serviceaccount.yaml
   - ./base/auth-proxy-deployment.yaml
   - ./base/auth-proxy-service.yaml
+  - ./base/externalsecret.yaml
 images:
   - name: polaris
     newName: ghcr.io/jlfowle/asterism-polaris


### PR DESCRIPTION
Add the missing ExternalSecret for the auth-proxy cookie secret and include it in the Polaris deploy kustomization. The auth-proxy rollout was blocked because the Deployment mounted a secret that GitOps never created, so this wires the secret to /asterism/auth-proxy and keeps the pod from failing its mount before startup.