### PR TITLE
fix(deploy): point auth proxy upstream at polaris service

### DIFF
--- a/docs/deploy-standards.md
+++ b/docs/deploy-standards.md
@@ -49,6 +49,7 @@ deploy/
 - `deploy/platform/routing/` contains Asterism's Gateway API `HTTPRoute` resources for the single public entry point
 - `deploy/platform/security/` contains infrastructure cross-cutting concerns, not service-owned
 - The public host is fronted by the Polaris auth proxy deployment in `services/polaris/deploy/base/auth-proxy-*`; it owns the OpenShift OAuth edge and forwards trusted user identity into Polaris and downstream APIs
+- The auth proxy upstream should target the in-cluster `polaris` Service, not the public or internal ingress hostname, so login callbacks do not bounce through an extra edge hop
 - When the auth proxy runs behind the OpenShift edge route without a mounted serving cert, it must set `--https-address=` so oauth-proxy stays HTTP-only and does not crash while loading TLS config
 - The consolidation is a simple aggregation via kustomize resource references
 

--- a/services/polaris/deploy/base/auth-proxy-deployment.yaml
+++ b/services/polaris/deploy/base/auth-proxy-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           args:
             - --http-address=0.0.0.0:4180
             - --https-address=
-            - --upstream=http://asterism-internal.apps.os.fowler.house/
+            - --upstream=http://polaris/
             - --openshift-service-account=asterism-auth-proxy
             - '--openshift-sar={"namespace":"$(POD_NAMESPACE)","resource":"services","resourceName":"asterism-auth-proxy","verb":"get"}'
             - --cookie-secret-file=/etc/oauth-proxy-cookie/cookie-secret


### PR DESCRIPTION
## Summary\n- Point the OpenShift auth proxy upstream at the in-cluster Polaris Service to avoid bouncing through the external/internal ingress hostname after login.\n- Document the upstream rule in deploy standards so the deployment contract stays explicit.\n\n## Validation\n- kustomize build services/polaris/deploy | rg -n "upstream=|asterism-internal|polaris/"\n- kubectl -n app-asterism exec pod/polaris-8fd654f7f-d9hz8 -c polaris -- sh -lc 'wget -qSO- http://127.0.0.1:8080/'