### PR TITLE
fix(ci): disable automatic PR branch updates

### DIFF
--- a/.github/workflows/update-pr-branches.yaml
+++ b/.github/workflows/update-pr-branches.yaml
@@ -1,9 +1,6 @@
 name: Update PR Branches
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary\n- Remove the push-to-main trigger from the PR branch updater workflow so open PRs are no longer automatically updated after every merge to main.\n- Keep the workflow available for manual  runs when branch refreshes are actually desired.\n\n## Validation\n- git diff --check\n- Reviewed the workflow to confirm only the push trigger was removed.