### PR TITLE
fix: normalize auth proxy upstream host header

### DIFF
--- a/docs/authn-authz-rollout-verification.md
+++ b/docs/authn-authz-rollout-verification.md
@@ -13,9 +13,11 @@ This checklist is the working verification plan for the OpenShift OAuth edge pro
 
 - [ ] Unauthenticated `GET /` reaches the OpenShift login gate through oauth-proxy
 - [ ] Authenticated `GET /` renders the Polaris shell
+- [ ] Authenticated `GET /` does not return a 503 or upstream reset from oauth-proxy
 - [ ] Sign-out returns through the OpenShift OAuth logout path
 - [ ] Public requests use `GET`, not `HEAD`, when checking the routed edge behavior
 - [ ] `asterism-internal.apps.os.fowler.house` serves the Polaris shell without routing back through the auth proxy
+- [ ] oauth-proxy forwards the shell service Host header upstream, not the public browser host
 
 ## Service Authorization Checks
 

--- a/docs/deploy-standards.md
+++ b/docs/deploy-standards.md
@@ -50,6 +50,7 @@ deploy/
 - `deploy/platform/security/` contains infrastructure cross-cutting concerns, not service-owned
 - The public host is fronted by the Polaris auth proxy deployment in `services/polaris/deploy/base/auth-proxy-*`; it owns the OpenShift OAuth edge and forwards trusted user identity into Polaris and downstream APIs
 - The auth proxy upstream should target the in-cluster `polaris` Service, not the public or internal ingress hostname, so login callbacks do not bounce through an extra edge hop
+- When oauth-proxy fronts Polaris, disable `--pass-host-header` so the upstream hop uses the shell service Host header. The browser host header can trigger Istio to reject the request with a 503/reset even when the shell pod itself is healthy.
 - When the auth proxy runs behind the OpenShift edge route without a mounted serving cert, it must set `--https-address=` so oauth-proxy stays HTTP-only and does not crash while loading TLS config
 - The consolidation is a simple aggregation via kustomize resource references
 

--- a/services/polaris/deploy/base/auth-proxy-deployment.yaml
+++ b/services/polaris/deploy/base/auth-proxy-deployment.yaml
@@ -36,6 +36,7 @@ spec:
             - --http-address=0.0.0.0:4180
             - --https-address=
             - --upstream=http://polaris/
+            - --pass-host-header=false
             - --openshift-service-account=asterism-auth-proxy
             - '--openshift-sar={"namespace":"$(POD_NAMESPACE)","resource":"services","resourceName":"asterism-auth-proxy","verb":"get"}'
             - --cookie-secret-file=/etc/oauth-proxy-cookie/cookie-secret


### PR DESCRIPTION
Fix authenticated 503s at the public edge by disabling oauth-proxy host-header passthrough. The proxy still routes to the in-cluster polaris Service, but upstream requests now use the shell service host header so Istio reaches the Polaris pod cleanly.\n\nValidation:\n- kustomize build services/polaris/deploy\n- make render-deploy\n- make test\n- live cluster repro: auth-proxy pod returns 503 when upstream Host is the public browser host and 200 when it uses the shell service host