### PR TITLE
fix(auth): align service-account live validation

### DIFF
--- a/deploy/platform/security/authorization-policy.yaml
+++ b/deploy/platform/security/authorization-policy.yaml
@@ -24,14 +24,14 @@ spec:
               - cluster.local/ns/istio-ingress/sa/default
         - source:
             principals:
-              - cluster.local/ns/asterism/sa/default
+              - cluster.local/ns/app-asterism/sa/default
     - from:
         - source:
             principals:
               - cluster.local/ns/istio-ingress/sa/default
         - source:
             principals:
-              - cluster.local/ns/asterism/sa/default
+              - cluster.local/ns/app-asterism/sa/default
       to:
         - operation:
             methods:

--- a/docs/authn-authz-rollout-verification.md
+++ b/docs/authn-authz-rollout-verification.md
@@ -14,6 +14,7 @@ This checklist is the working verification plan for the OpenShift OAuth edge pro
 - [ ] Unauthenticated `GET /` reaches the OpenShift login gate through oauth-proxy
 - [ ] Authenticated `GET /` renders the Polaris shell
 - [ ] Authenticated `GET /` does not return a 503 or upstream reset from oauth-proxy
+- [ ] A short-lived OpenShift service-account bearer token can reach the same public host without browser SSO
 - [ ] Sign-out returns through the OpenShift OAuth logout path
 - [ ] Public requests use `GET`, not `HEAD`, when checking the routed edge behavior
 - [ ] `asterism-internal.apps.os.fowler.house` serves the Polaris shell through the same auth-proxy front door

--- a/services/polaris/deploy/base/auth-proxy-deployment.yaml
+++ b/services/polaris/deploy/base/auth-proxy-deployment.yaml
@@ -37,6 +37,7 @@ spec:
             - --https-address=
             - --upstream=http://polaris/
             - --pass-host-header=false
+            - '--openshift-delegate-urls={"/":{"resource":"services","resourceName":"asterism-auth-proxy","verb":"get"}}'
             - --openshift-service-account=asterism-auth-proxy
             - '--openshift-sar={"namespace":"$(POD_NAMESPACE)","resource":"services","resourceName":"asterism-auth-proxy","verb":"get"}'
             - --cookie-secret-file=/etc/oauth-proxy-cookie/cookie-secret


### PR DESCRIPTION
## Summary
- Add OpenShift delegate URL handling for the auth proxy so bearer-token service-account requests can authenticate without Cognito.
- Update the Istio service principal to match the deployed app namespace.
- Document the service-account validation path in the rollout checklist.

## Validation
- `make render-deploy`
- `kustomize build deploy > /dev/null`

## Companion work
- os-config branch: `codex/os-config-asterism-live-validator-sso`