### PR TITLE
fix(polaris): add auth proxy auth delegator binding

### DIFF
--- a/services/polaris/deploy/base/auth-proxy-auth-delegator.yaml
+++ b/services/polaris/deploy/base/auth-proxy-auth-delegator.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: asterism-auth-proxy-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: asterism-auth-proxy
+    namespace: asterism

--- a/services/polaris/deploy/kustomization.yaml
+++ b/services/polaris/deploy/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./base/service.yaml
   - ./base/runtime-config-configmap.yaml
   - ./base/auth-proxy-serviceaccount.yaml
+  - ./base/auth-proxy-auth-delegator.yaml
   - ./base/auth-proxy-deployment.yaml
   - ./base/auth-proxy-service.yaml
   - ./base/externalsecret.yaml


### PR DESCRIPTION
## Summary
- Add a ClusterRoleBinding for the auth-proxy service account to `system:auth-delegator` in the Polaris deploy base.
- This is the release-source fix that must land in the rendered Asterism asset so token-based edge auth can succeed in the live cluster.

## Changes
- `services/polaris/deploy/kustomization.yaml`
- `services/polaris/deploy/base/auth-proxy-auth-delegator.yaml`

## Validation
- `git diff --check`
- `kustomize build services/polaris/deploy | rg -n "asterism-auth-proxy-auth-delegator|system:auth-delegator|kind: ClusterRoleBinding"

## Live context
- The live cluster still needs this RBAC in the release asset before bearer-token requests can bypass the login gate.