### PR TITLE
fix(polaris): remove dead navigation links

### DIFF
--- a/services/polaris/src/components/Sidebar.js
+++ b/services/polaris/src/components/Sidebar.js
@@ -18,8 +18,6 @@ const Sidebar = ({ auth }) => (
     <ul>
       <li><a href="#dashboard">Dashboard</a></li>
       <li><a href="#integrations">Integrations</a></li>
-      <li><a href="#security">Security</a></li>
-      <li><a href="#events">Events</a></li>
     </ul>
     <div className="sidebar-footnote">
       External identity: {sidebarIdentityLabel(auth)}

--- a/services/polaris/src/components/Sidebar.test.js
+++ b/services/polaris/src/components/Sidebar.test.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import Sidebar from "./Sidebar";
 
 test("renders sidebar links", () => {
-  const { getByText } = render(<Sidebar auth={{ ready: true, modeLabel: "OpenShift SSO" }} />);
-  expect(getByText("Dashboard")).toBeInTheDocument();
-  expect(getByText("Integrations")).toBeInTheDocument();
-  expect(getByText("Security")).toBeInTheDocument();
-  expect(getByText(/External identity: OpenShift SSO/)).toBeInTheDocument();
+  render(<Sidebar auth={{ ready: true, modeLabel: "OpenShift SSO" }} />);
+  expect(screen.getByText("Dashboard")).toBeInTheDocument();
+  expect(screen.getByText("Integrations")).toBeInTheDocument();
+  expect(screen.queryByText("Security")).toBeNull();
+  expect(screen.getByText(/External identity: OpenShift SSO/)).toBeInTheDocument();
 });


### PR DESCRIPTION
Remove the sidebar links that pointed at sections Polaris does not render yet. This keeps the cockpit honest while we decide whether to add real read-only Security and Events sections later.\n\nValidation:\n- yarn test --runInBand\n- yarn lint src/components/Sidebar.js src/components/Sidebar.test.js\n- signed commit on branch codex/asterism-sidebar-remove-dead-nav