### PR TITLE
feat(polaris): generate microfrontend registry

### DIFF
--- a/scripts/generate-microfrontends-registry.sh
+++ b/scripts/generate-microfrontends-registry.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SERVICES_DIR="$REPO_ROOT/services"
+OUTPUT_PATH="$REPO_ROOT/services/polaris/public/microfrontends.json"
+MODE="write"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/generate-microfrontends-registry.sh [--write|--check]
+
+Generate the Polaris microfrontend registry from the shared service inventory.
+  --write  Regenerate services/polaris/public/microfrontends.json (default)
+  --check  Fail if the committed registry is out of date
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --write)
+      MODE="write"
+      ;;
+    --check)
+      MODE="check"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+inventory_json="$(cd "$SERVICES_DIR" && ./inventory.sh)"
+registry_services='[]'
+
+while IFS= read -r service_id; do
+  module_path="$REPO_ROOT/services/$service_id/ui/module.json"
+  if [[ ! -f "$module_path" ]]; then
+    continue
+  fi
+
+  entry="$(
+    jq -cn \
+      --arg service "$service_id" \
+      --slurpfile module_file "$module_path" '
+        def join_path(base; path):
+          if (base // "") == "" then
+            path
+          elif (path // "") == "" then
+            base
+          elif path | startswith("/") then
+            base + path
+          else
+            base + "/" + path
+          end;
+
+        ($module_file[0]) as $manifest
+        | {
+            id: ($manifest.service // $service),
+            displayName: ($manifest.dashboardCard.title // $manifest.displayName // $service),
+            description: ($manifest.dashboardCard.description // ""),
+            statusApi: join_path(($manifest.apiBasePath // ""); ($manifest.dashboardCard.statusEndpoint // "")),
+            moduleManifest: join_path(($manifest.uiBasePath // ""); "module.json")
+          }
+      '
+  )"
+
+  registry_services="$(
+    jq -cn \
+      --argjson current "$registry_services" \
+      --argjson entry "$entry" \
+      '$current + [$entry]'
+  )"
+done < <(
+  jq -r '
+    .[]
+    | select(.containerized == true and .has_kustomize_deployment == true)
+    | .id
+  ' <<<"$inventory_json"
+)
+
+rendered_registry="$(
+  jq -n --argjson services "$registry_services" '{services: $services}'
+)"
+
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+printf '%s\n' "$rendered_registry" | jq '.' > "$tmp_file"
+
+if [[ "$MODE" == "check" ]]; then
+  if ! diff -u "$OUTPUT_PATH" "$tmp_file"; then
+    echo "Polaris microfrontend registry is out of date. Run: scripts/generate-microfrontends-registry.sh --write" >&2
+    exit 1
+  fi
+  echo "Polaris microfrontend registry is up to date."
+  exit 0
+fi
+
+mv "$tmp_file" "$OUTPUT_PATH"
+trap - EXIT
+echo "Updated $OUTPUT_PATH"

--- a/scripts/update-deploy.sh
+++ b/scripts/update-deploy.sh
@@ -104,6 +104,10 @@ main() {
             echo "  - $service"
         done
     fi
+
+    echo ""
+    echo -e "${BLUE}Generating Polaris microfrontend registry...${NC}"
+    "$REPO_ROOT/scripts/generate-microfrontends-registry.sh" --write
     
     # Generate kustomization
     echo ""

--- a/services/polaris/Makefile
+++ b/services/polaris/Makefile
@@ -1,18 +1,21 @@
-.PHONY: run build test lint deps clean
+.PHONY: run build test lint deps clean verify-registry
 
-run: deps
+run: deps verify-registry
 	yarn start
 
-build: dist/main.js
+build: verify-registry dist/main.js
 
 dist/main.js: $(wildcard src/**/*.js) deps
 	yarn build
 
-test: deps
+test: deps verify-registry
 	yarn test
 
-lint: deps
+lint: deps verify-registry
 	yarn lint
+
+verify-registry:
+	../../scripts/generate-microfrontends-registry.sh --check
 
 deps:
 	yarn install --frozen-lockfile --check-files

--- a/services/polaris/public/microfrontends.json
+++ b/services/polaris/public/microfrontends.json
@@ -1,25 +1,25 @@
 {
   "services": [
     {
-      "id": "unifi",
-      "displayName": "UniFi",
-      "description": "Wireless controller health and client telemetry.",
-      "statusApi": "/api/services/unifi/api/v1/status",
-      "moduleManifest": "/ui/services/unifi/module.json"
-    },
-    {
       "id": "cluster",
-      "displayName": "OpenShift",
-      "description": "Cluster workload and node status from in-cluster APIs.",
+      "displayName": "OpenShift Cluster",
+      "description": "Node, workload, operator, and GitOps status from read-only cluster APIs.",
       "statusApi": "/api/services/cluster/api/v1/status",
       "moduleManifest": "/ui/services/cluster/module.json"
     },
     {
       "id": "pfsense",
-      "displayName": "pfSense",
-      "description": "Gateway availability and network edge insights.",
+      "displayName": "pfSense Gateway",
+      "description": "Firewall and gateway status from read-only pfSense SNMP.",
       "statusApi": "/api/services/pfsense/api/v1/status",
       "moduleManifest": "/ui/services/pfsense/module.json"
+    },
+    {
+      "id": "unifi",
+      "displayName": "UniFi Network",
+      "description": "Wireless, network device, and client status from the local UniFi Network API.",
+      "statusApi": "/api/services/unifi/api/v1/status",
+      "moduleManifest": "/ui/services/unifi/module.json"
     }
   ]
 }

--- a/services/polaris/src/App.test.js
+++ b/services/polaris/src/App.test.js
@@ -11,7 +11,7 @@ test("renders the dashboard layout", async () => {
     expect(getByText("Polaris Mission Console")).toBeInTheDocument();
     expect(getByText("Dashboard")).toBeInTheDocument();
     expect(getByText("Operator Cockpit")).toBeInTheDocument();
-    expect(getByText("UniFi")).toBeInTheDocument();
+    expect(getByText("UniFi Network")).toBeInTheDocument();
     expect(await screen.findByText("Local development")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
   } finally {

--- a/services/polaris/src/components/MainContent.js
+++ b/services/polaris/src/components/MainContent.js
@@ -1,28 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
+import fallbackRegistry from "../../public/microfrontends.json";
 
-const FALLBACK_SERVICES = [
-  {
-    id: "unifi",
-    displayName: "UniFi",
-    description: "Wireless controller health and client telemetry.",
-    statusApi: "/api/services/unifi/api/v1/status",
-    moduleManifest: "/ui/services/unifi/module.json",
-  },
-  {
-    id: "cluster",
-    displayName: "OpenShift",
-    description: "Cluster workload and node status from in-cluster APIs.",
-    statusApi: "/api/services/cluster/api/v1/status",
-    moduleManifest: "/ui/services/cluster/module.json",
-  },
-  {
-    id: "pfsense",
-    displayName: "pfSense",
-    description: "Gateway availability and network edge insights.",
-    statusApi: "/api/services/pfsense/api/v1/status",
-    moduleManifest: "/ui/services/pfsense/module.json",
-  },
-];
+const FALLBACK_SERVICES = Array.isArray(fallbackRegistry?.services)
+  ? fallbackRegistry.services
+  : [];
 
 const STATUS_STATE = {
   IDLE: "idle",

--- a/services/polaris/src/components/MainContent.test.js
+++ b/services/polaris/src/components/MainContent.test.js
@@ -5,9 +5,9 @@ import MainContent from "./MainContent";
 test("renders welcome message", () => {
   const { getByText } = render(<MainContent />);
   expect(getByText("Operator Cockpit")).toBeInTheDocument();
-  expect(getByText("UniFi")).toBeInTheDocument();
-  expect(getByText("OpenShift")).toBeInTheDocument();
-  expect(getByText("pfSense")).toBeInTheDocument();
+  expect(getByText("UniFi Network")).toBeInTheDocument();
+  expect(getByText("OpenShift Cluster")).toBeInTheDocument();
+  expect(getByText("pfSense Gateway")).toBeInTheDocument();
 });
 
 test("hydrates cards from service-owned module manifests", async () => {


### PR DESCRIPTION
## Summary
- generate \ from the shared service inventory and service-owned module manifests
- make Polaris use the generated registry as its fallback source and verify it stays in sync during local/CI builds
- fold registry regeneration into \ so deploy discovery and shell discovery move together

## Validation
- \
- \
- \
- \
